### PR TITLE
Enhance Image Uploads to Support Multiple Files with Shared Metadata

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -218,8 +218,8 @@ function handleUpload(event) {
 
     <div class="toggle-container">
         <div id="uploadForm" style="display: none;">
-            <form action="{{ url_for('upload_image') }}" method="post" enctype="multipart/form-data" id="upload-form">
-                <input class="file-button" type="file" name="file" id="fileInput" accept=".jpg,.jpeg,.png,.gif,.webp,.heif,.pdf" required onchange="validateFile(this)"><br>
+            <form action="{{ url_for('upload_images') }}" method="post" enctype="multipart/form-data" id="upload-form">
+                <input class="file-button" type="file" name="files" id="fileInput" multiple accept=".jpg,.jpeg,.png,.gif,.webp,.heif,.pdf" required onchange="validateFile(this)"><br>            
                 <input class="title-area" type="text" name="title" placeholder="Title" required><br>
                 <textarea class="description-area" name="description" placeholder="Description" required></textarea><br>
                 


### PR DESCRIPTION
What:
This PR enhances the image upload feature to support multiple image uploads at once, with shared metadata applied across all selected images.

Why:
The ability to upload multiple images simultaneously improves user convenience and efficiency, especially in scenarios involving bulk contributions. Supporting shared metadata ensures consistency and reduces repetitive tasks for users.

How:

- Updated backend logic to handle multiple image files in a single upload request.
- Ensured compatibility with the existing upload validation, storage, and processing mechanism.

i.e:
![image](https://github.com/user-attachments/assets/95e1cbdc-116f-4851-bda8-bf94def3656f)

*Checklist:*
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)


