### PR TITLE
Feature Added: Image Preview Feature for User and Admin Page with Modal

### DIFF
--- a/app.py
+++ b/app.py
@@ -294,9 +294,18 @@ def getallusers():
 
 @app.route('/admin/users/<username>')
 def user_images_show(username):
-    images = get_images_by_user(username)
-    return render_template('user_images.html', images=images, username=username)
+    user = get_user_by_username(username)
+    if not user:
+        flash("User not found.", "danger")
+        return redirect(url_for('getallusers'))
 
+    images = get_images_by_user(username)
+    return render_template(
+        'user_images.html',
+        username=username,
+        images=images,
+        full_name=f"{user['first_name']} {user['last_name']}"
+    )
 
 
 if __name__ == '__main__':

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -79,4 +79,33 @@ body {
 .logout-button:hover {
     background-color: #d60400;
 }
+.image-preview-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.image-preview-modal img {
+    max-width: 90%;
+    max-height: 90%;
+    border: 5px solid white;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+}
+
+.image-preview-modal .close-btn {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    font-size: 30px;
+    color: white;
+    cursor: pointer;
+    font-weight: bold;
+}
 

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -209,3 +209,30 @@ h2{
 .edit-button:hover {
     background-color: #007906;
 }
+.image-preview-modal {
+    display: none; /* Hidden by default */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    z-index: 1000;
+    justify-content: center;
+    align-items: center;
+}
+
+.image-preview-modal img {
+    max-width: 90%;
+    max-height: 90%;
+    border-radius: 10px;
+}
+
+.image-preview-modal .close-btn {
+    position: absolute;
+    top: 20px;
+    right: 30px;
+    color: white;
+    font-size: 30px;
+    cursor: pointer;
+}

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -236,3 +236,32 @@ h2{
     font-size: 30px;
     cursor: pointer;
 }
+.image-preview-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.image-preview-modal img {
+    max-width: 90%;
+    max-height: 90%;
+    border: none;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+}
+
+.image-preview-modal .close-btn {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    font-size: 30px;
+    color: white;
+    cursor: pointer;
+    font-weight: bold;
+}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -34,6 +34,26 @@
                 editForm.style.display = 'none';
             }
         }
+
+        function previewImage(imageSrc) {
+            var modal = document.getElementById('imagePreviewModal');
+            var previewImg = document.getElementById('previewImage');
+            previewImg.src = imageSrc;
+            modal.style.display = 'flex'; // Show the modal
+        }
+        
+        function closePreview() {
+            var modal = document.getElementById('imagePreviewModal');
+            modal.style.display = 'none'; // Hide the modal
+        }
+        
+        // Close modal on pressing ESC key
+        document.addEventListener('keydown', function (event) {
+            if (event.key === "Escape") {
+                closePreview();
+            }
+        });
+        
     </script>
 </head>
 <body>
@@ -61,7 +81,12 @@
     <div class="image-container">
         {% for image in images %}
         <div class="image-card">
-            <img src="{{ url_for('static', filename='uploads/' ~ image.filename) }}" alt="{{ image.title }}">
+            <img 
+                src="{{ url_for('static', filename='uploads/' ~ image.filename) }}" 
+                alt="{{ image.title }}" 
+                onclick="previewImage(this.src)" 
+                style="cursor: pointer;"
+            >
             <h3>{{ image.title }}</h3>
             <p>{{ image.description }}</p>
             <button class="more-info-button" onclick="toggleMoreInfo('{{ image.id }}')">More Info</button>
@@ -78,6 +103,10 @@
             </div>
         </div>
         {% endfor %}
+    </div>
+    <div id="imagePreviewModal" class="image-preview-modal">
+        <span class="close-btn" onclick="closePreview()">&times;</span>
+        <img id="previewImage" src="" alt="Preview">
     </div>
 </body>
 </html>

--- a/templates/user_images.html
+++ b/templates/user_images.html
@@ -25,15 +25,39 @@
                 editForm.style.display = 'none';
             }
         }
+
+        function previewImage(imageSrc) {
+            var modal = document.getElementById('imagePreviewModal');
+            var previewImg = document.getElementById('previewImage');
+            previewImg.src = imageSrc; // Set the image source
+            modal.style.display = 'flex'; // Show the modal
+        }
+    
+        function closePreview() {
+            var modal = document.getElementById('imagePreviewModal');
+            modal.style.display = 'none'; // Hide the modal
+        }
+    
+        document.addEventListener('keydown', function (event) {
+            if (event.key === "Escape") {
+                closePreview();
+            }
+        });
     </script>
-    </script>
+
 </head>
 <body>
     <h2 style="text-align: center;">Uploaded Images</h2>
     <div class="image-container">
         {% for image in images %}
         <div class="image-card">
-            <img src="{{ url_for('static', filename='uploads/' ~ image.filename) }}" alt="{{ image.title }}">
+            <img 
+            src="{{ url_for('static', filename='uploads/' ~ image.filename) }}" 
+            alt="{{ image.title }}" 
+            onclick="previewImage(this.src)" 
+            style="cursor: pointer;"
+            >
+
             <h3>{{ image.title }}</h3>
             <p>{{ image.description }}</p>
             <button class="more-info-button" onclick="toggleMoreInfo('{{ image.id }}')">More Info</button>
@@ -51,6 +75,9 @@
         </div>
         {% endfor %}
     </div>
-    
+    <div id="imagePreviewModal" class="image-preview-modal">
+        <span class="close-btn" onclick="closePreview()">&times;</span>
+        <img id="previewImage" src="" alt="Preview">
+    </div>    
 </body>
 </html>


### PR DESCRIPTION
This PR implements an image preview feature for both user and admin pages, enabling images to be viewed in a modal without leaving the page. Key changes include:

- Full-screen modal display for clicked images with a dark background.
- Close modal using the (×) button or the ESC key.
- Compatibility ensured with existing functionality.

The output looks like this:
A)For User:
![Screenshot from 2025-01-23 19-47-29](https://github.com/user-attachments/assets/ccca3992-f2cf-4d0b-9988-cc6017dc72b9)
B)For Admin:
![Screenshot from 2025-01-24 01-58-39](https://github.com/user-attachments/assets/74d1eb78-6831-4985-8315-53343845ad66)

