### PR TITLE
Implement image preview feature for both user and admin pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -299,8 +299,18 @@ def getallusers():
 
 @app.route('/admin/users/<username>')
 def user_images_show(username):
+    user = get_user_by_username(username)
+    if not user:
+        flash("User not found.", "danger")
+        return redirect(url_for('getallusers'))
+    
     images = get_images_by_user(username)
-    return render_template('user_images.html', images=images, username=username)
+    return render_template(
+        'user_images.html',
+        username=username,
+        images=images,
+        full_name=f"{user['first_name']} {user['last_name']}"
+    )
 
 
 

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -103,3 +103,32 @@ body {
     color: #0e0e0e;
     margin-top: 10px;
 }
+.image-preview-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.image-preview-modal img {
+    max-width: 90%;
+    max-height: 90%;
+    border: 5px solid white;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+}
+
+.image-preview-modal .close-btn {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    font-size: 30px;
+    color: white;
+    cursor: pointer;
+    font-weight: bold;
+}

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -237,3 +237,33 @@ h2{
     font-size: 30px;
     cursor: pointer;
 }
+
+.image-preview-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.image-preview-modal img {
+    max-width: 90%;
+    max-height: 90%;
+    border: none;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+}
+
+.image-preview-modal .close-btn {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    font-size: 30px;
+    color: white;
+    cursor: pointer;
+    font-weight: bold;
+}

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -209,3 +209,31 @@ h2{
 .edit-button:hover {
     background-color: #007906;
 }
+
+.image-preview-modal {
+    display: none; /* Hidden by default */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    z-index: 1000;
+    justify-content: center;
+    align-items: center;
+}
+
+.image-preview-modal img {
+    max-width: 90%;
+    max-height: 90%;
+    border-radius: 10px;
+}
+
+.image-preview-modal .close-btn {
+    position: absolute;
+    top: 20px;
+    right: 30px;
+    color: white;
+    font-size: 30px;
+    cursor: pointer;
+}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -34,6 +34,25 @@
                 editForm.style.display = 'none';
             }
         }
+
+        function previewImage(imageSrc) {
+            var modal = document.getElementById('imagePreviewModal');
+            var previewImg = document.getElementById('previewImage');
+            previewImg.src = imageSrc;
+            modal.style.display = 'flex'; // Show the modal
+        }
+
+        function closePreview() {
+            var modal = document.getElementById('imagePreviewModal');
+            modal.style.display = 'none'; // Hide the modal
+        }
+
+        // Close modal on pressing ESC key
+        document.addEventListener('keydown', function (event) {
+            if (event.key === "Escape") {
+                closePreview();
+            }
+        });
     </script>
 </head>
 <body>
@@ -61,7 +80,12 @@
     <div class="image-container">
         {% for image in images %}
         <div class="image-card">
-            <img src="{{ url_for('static', filename='uploads/' ~ image.filename) }}" alt="{{ image.title }}">
+            <img 
+                src="{{ url_for('static', filename='uploads/' ~ image.filename) }}" 
+                alt="{{ image.title }}" 
+                onclick="previewImage(this.src)" 
+                style="cursor: pointer;"
+            >
             <h3>{{ image.title }}</h3>
             <p>{{ image.description }}</p>
             <button class="more-info-button" onclick="toggleMoreInfo('{{ image.id }}')">More Info</button>
@@ -78,6 +102,10 @@
             </div>
         </div>
         {% endfor %}
+    </div>
+    <div id="imagePreviewModal" class="image-preview-modal">
+        <span class="close-btn" onclick="closePreview()">&times;</span>
+        <img id="previewImage" src="" alt="Preview">
     </div>
 </body>
 </html>

--- a/templates/user_images.html
+++ b/templates/user_images.html
@@ -25,6 +25,24 @@
                 editForm.style.display = 'none';
             }
         }
+
+        function previewImage(imageSrc) {
+            var modal = document.getElementById('imagePreviewModal');
+            var previewImg = document.getElementById('previewImage');
+            previewImg.src = imageSrc; // Set the image source
+            modal.style.display = 'flex'; // Show the modal
+        }
+
+        function closePreview() {
+            var modal = document.getElementById('imagePreviewModal');
+            modal.style.display = 'none'; // Hide the modal
+        }
+
+        document.addEventListener('keydown', function (event) {
+            if (event.key === "Escape") {
+                closePreview();
+            }
+        });
     </script>
     </script>
 </head>
@@ -33,7 +51,12 @@
     <div class="image-container">
         {% for image in images %}
         <div class="image-card">
-            <img src="{{ url_for('static', filename='uploads/' ~ image.filename) }}" alt="{{ image.title }}">
+            <img 
+            src="{{ url_for('static', filename='uploads/' ~ image.filename) }}" 
+            alt="{{ image.title }}" 
+            onclick="previewImage(this.src)" 
+            style="cursor: pointer;"
+            >
             <h3>{{ image.title }}</h3>
             <p>{{ image.description }}</p>
             <button class="more-info-button" onclick="toggleMoreInfo('{{ image.id }}')">More Info</button>
@@ -51,6 +74,9 @@
         </div>
         {% endfor %}
     </div>
-    
+    <div id="imagePreviewModal" class="image-preview-modal">
+        <span class="close-btn" onclick="closePreview()">&times;</span>
+        <img id="previewImage" src="" alt="Preview">
+    </div>  
 </body>
 </html>


### PR DESCRIPTION
## What:
This PR implements an image preview feature for both user and admin pages. This allows users to view images in a modal window without leaving the page.

## Why:
This feature enhances user and admin experience by allowing them to quickly review uploaded images without navigating away from the current page, reducing unnecessary clicks and improving workflow efficiency.

## How:
- Full-screen modal display for clicked images with a dark background.
- Option to close the modal using the (×) button or the ESC key for convenience.
- Optimised for performance with quick loading and responsive image display.
- Integrated with existing functionality, ensuring compatibility with both user and admin pages.


**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)