### PR TITLE
Add file type validation for image uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from OAuth.config import ALLOWED_EMAILS, GOOGLE_CLIENT_ID
 
-ALLOWED_EXTENSIONS = {'jpg', 'jpeg', 'png', 'gif', 'webp', 'heif'}
+ALLOWED_EXTENSIONS = {'jpg', 'jpeg', 'png', 'gif', 'webp', 'heif', 'pdf'}
 
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
@@ -161,7 +161,7 @@ def upload_image():
         save_image(user['username'], filename, title, description, time_created)
         flash('Image uploaded successfully!', 'success')
     else:
-        flash('Invalid file type. Allowed types are: jpg, jpeg, png, gif, webp, heif', 'danger')
+        flash('Invalid file type. Allowed types are: jpg, jpeg, png, gif, webp, heif, pdf', 'danger')
 
     return redirect(url_for('profile'))
 

--- a/app.py
+++ b/app.py
@@ -37,6 +37,10 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from OAuth.config import ALLOWED_EMAILS, GOOGLE_CLIENT_ID
 
+ALLOWED_EXTENSIONS = {'jpg', 'jpeg', 'png', 'gif', 'webp', 'heif'}
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
 app = Flask(__name__)
 app.secret_key = 'beehive'
@@ -148,7 +152,7 @@ def upload_image():
     title = request.form['title']
     description = request.form['description']
 
-    if file:
+    if file and allowed_file(file.filename):
         filename = file.filename
         filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         os.makedirs(os.path.dirname(filepath), exist_ok=True)
@@ -157,7 +161,7 @@ def upload_image():
         save_image(user['username'], filename, title, description, time_created)
         flash('Image uploaded successfully!', 'success')
     else:
-        flash('No file selected.', 'danger')
+        flash('Invalid file type. Allowed types are: jpg, jpeg, png, gif, webp, heif', 'danger')
 
     return redirect(url_for('profile'))
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -35,6 +35,7 @@
             }
         }
 
+<<<<<<< HEAD
         function previewImage(imageSrc) {
             var modal = document.getElementById('imagePreviewModal');
             var previewImg = document.getElementById('previewImage');
@@ -61,6 +62,28 @@
         setTimeout(() => flashMessages.style.display = "none", 500);
       }
     }, 5000);
+=======
+        function validateFile(input) {
+            const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/heif'];
+            const uploadButton = document.getElementById('uploadButton');
+            const fileError = document.getElementById('fileError');
+            
+            if (input.files && input.files[0]) {
+                const file = input.files[0];
+                const fileExtension = file.name.split('.').pop().toLowerCase();
+                
+                if (!allowedTypes.includes(file.type) || 
+                    !['jpg', 'jpeg', 'png', 'gif', 'webp', 'heif'].includes(fileExtension)) {
+                    uploadButton.disabled = true;
+                    fileError.style.display = 'block';
+                    input.value = ''; // Clear the file input
+                } else {
+                    uploadButton.disabled = false;
+                    fileError.style.display = 'none';
+                }
+            }
+        }
+>>>>>>> af7d8e3 (feat: Add image file type validation (.jpg, .jpeg, .png, .gif, .webp, .heif))
     </script>
 </head>
 <body>
@@ -88,10 +111,11 @@
     <div class="toggle-container">
         <div id="uploadForm" style="display: none;">
             <form action="{{ url_for('upload_image') }}" method="post" enctype="multipart/form-data">
-                <input class="file-button" type="file" name="file" required><br>
+                <input class="file-button" type="file" name="file" id="fileInput" accept=".jpg,.jpeg,.png,.gif,.webp,.heif" required onchange="validateFile(this)"><br>
                 <input class="title-area" type="text" name="title" placeholder="Title" required><br>
                 <textarea class="description-area" name="description" placeholder="Description" required></textarea><br>
-                <button class="upload-button" type="submit">Upload</button>
+                <button class="upload-button" type="submit" id="uploadButton">Upload</button>
+                <div id="fileError" style="color: red; display: none;">Invalid file type. Only jpg, jpeg, png, gif, webp, and heif files are allowed.</div>
             </form>
         </div>
     </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -35,7 +35,7 @@
             }
         }
 
-<<<<<<< HEAD
+
         function previewImage(imageSrc) {
             var modal = document.getElementById('imagePreviewModal');
             var previewImg = document.getElementById('previewImage');
@@ -62,7 +62,7 @@
         setTimeout(() => flashMessages.style.display = "none", 500);
       }
     }, 5000);
-=======
+
         function validateFile(input) {
             const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/heif'];
             const uploadButton = document.getElementById('uploadButton');
@@ -83,7 +83,7 @@
                 }
             }
         }
->>>>>>> af7d8e3 (feat: Add image file type validation (.jpg, .jpeg, .png, .gif, .webp, .heif))
+
     </script>
 </head>
 <body>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -64,7 +64,7 @@
     }, 5000);
 
         function validateFile(input) {
-            const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/heif'];
+            const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/heif', 'application/pdf'];
             const uploadButton = document.getElementById('uploadButton');
             const fileError = document.getElementById('fileError');
             
@@ -73,7 +73,7 @@
                 const fileExtension = file.name.split('.').pop().toLowerCase();
                 
                 if (!allowedTypes.includes(file.type) || 
-                    !['jpg', 'jpeg', 'png', 'gif', 'webp', 'heif'].includes(fileExtension)) {
+                    !['jpg', 'jpeg', 'png', 'gif', 'webp', 'heif', 'pdf'].includes(fileExtension)) {
                     uploadButton.disabled = true;
                     fileError.style.display = 'block';
                     input.value = ''; // Clear the file input
@@ -111,11 +111,11 @@
     <div class="toggle-container">
         <div id="uploadForm" style="display: none;">
             <form action="{{ url_for('upload_image') }}" method="post" enctype="multipart/form-data">
-                <input class="file-button" type="file" name="file" id="fileInput" accept=".jpg,.jpeg,.png,.gif,.webp,.heif" required onchange="validateFile(this)"><br>
+                <input class="file-button" type="file" name="file" id="fileInput" accept=".jpg,.jpeg,.png,.gif,.webp,.heif,.pdf" required onchange="validateFile(this)"><br>
                 <input class="title-area" type="text" name="title" placeholder="Title" required><br>
                 <textarea class="description-area" name="description" placeholder="Description" required></textarea><br>
                 <button class="upload-button" type="submit" id="uploadButton">Upload</button>
-                <div id="fileError" style="color: red; display: none;">Invalid file type. Only jpg, jpeg, png, gif, webp, and heif files are allowed.</div>
+                <div id="fileError" style="color: red; display: none;">Invalid file type. Only jpg, jpeg, png, gif, webp,heif and pdf files are allowed.</div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
## What:
Implemented client and server-side validation to restrict image upload types to specific formats (.jpg, .jpeg, .png, .gif, .webp, .heif and .pdf).

## Why:
- Prevent users from uploading unsupported file formats
- Improve user experience by providing immediate feedback
- Reduce server load by filtering invalid files before upload

## How:
1. Added client-side validation:
   - File type restrictions in file picker dialog
   - JavaScript validation to disable upload button for invalid files
   - Immediate user feedback for invalid selections

2. Added server-side validation:
   - Implemented ALLOWED_EXTENSIONS check
   - Added allowed_file() helper function
   - Modified upload_image route to validate files

3. User Interface Updates:
   - Added error message display for invalid files
   - Disabled upload button when invalid file is selected
   - Added accept attribute to file input for better UX

## Testing:
- Verified validation works for all supported file types
- Confirmed error messages display correctly
- Validated both client and server-side checks working

## Screenshot:
![Attachment01](https://github.com/user-attachments/assets/1ace5720-39f3-4877-8f34-243179f65beb)


**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)