### PR TITLE
Add Client and Server-Side Validation for Image Uploads(Main Branch)

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,10 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from OAuth.config import ALLOWED_EMAILS, GOOGLE_CLIENT_ID
 
+ALLOWED_EXTENSIONS = {'jpg', 'jpeg', 'png', 'gif', 'webp', 'heif', 'pdf'}
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
 app = Flask(__name__)
 app.secret_key = 'beehive'
@@ -174,7 +178,7 @@ def upload_image():
     title = request.form['title']
     description = request.form['description']
 
-    if file:
+    if file and allowed_file(file.filename):
         filename = file.filename
         filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         os.makedirs(os.path.dirname(filepath), exist_ok=True)
@@ -182,7 +186,7 @@ def upload_image():
         save_image(user['username'], filename, title, description)
         flash('Image uploaded successfully!', 'success')
     else:
-        flash('No file selected.', 'danger')
+        flash('Invalid file type. Allowed types are: jpg, jpeg, png, gif, webp, heif, pdf', 'danger')
 
     return redirect(url_for('profile'))
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -34,6 +34,28 @@
                 editForm.style.display = 'none';
             }
         }
+
+        function validateFile(input) {
+            const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/heif', 'application/pdf'];
+            const uploadButton = document.getElementById('uploadButton');
+            const fileError = document.getElementById('fileError');
+
+            if (input.files && input.files[0]) {
+                const file = input.files[0];
+                const fileExtension = file.name.split('.').pop().toLowerCase();
+
+                if (!allowedTypes.includes(file.type) || 
+                    !['jpg', 'jpeg', 'png', 'gif', 'webp', 'heif', 'pdf'].includes(fileExtension)) {
+                    uploadButton.disabled = true;
+                    fileError.style.display = 'block';
+                    input.value = ''; // Clear the file input
+                } else {
+                    uploadButton.disabled = false;
+                    fileError.style.display = 'none';
+                }
+            }
+        }
+
     </script>
 </head>
 <body>
@@ -49,10 +71,11 @@
     <div class="toggle-container">
         <div id="uploadForm" style="display: none;">
             <form action="{{ url_for('upload_image') }}" method="post" enctype="multipart/form-data">
-                <input class="file-button" type="file" name="file" required><br>
+                <input class="file-button" type="file" name="file" id="fileInput" accept=".jpg,.jpeg,.png,.gif,.webp,.heif,.pdf" required onchange="validateFile(this)"><br>
                 <input class="title-area" type="text" name="title" placeholder="Title" required><br>
                 <textarea class="description-area" name="description" placeholder="Description" required></textarea><br>
-                <button class="upload-button" type="submit">Upload</button>
+                <button class="upload-button" type="submit" id="uploadButton">Upload</button>
+                <div id="fileError" style="color: red; display: none;">Invalid file type. Only jpg, jpeg, png, gif, webp,heif and pdf files are allowed.</div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
This implements client and server-side validation to restrict image uploads to specific formats (.jpg, .jpeg, .png, .gif, .webp, .heif, .pdf).
It prevents unsupported file uploads, improves UX with immediate feedback, and reduces server load. 

## Changes include:
- File type restrictions in the picker
- JavaScript validation
- error message on selecting other formats.
- server-side checks using ALLOWED_EXTENSIONS and allowed_file() in the upload route.

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)