### PR TITLE
Add page-wide drag and drop functionality for file uploads

### DIFF
--- a/static/js/dragdrop.js
+++ b/static/js/dragdrop.js
@@ -1,0 +1,67 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const fileInput = document.querySelector('input[type="file"]');
+    const uploadButton = document.getElementById('uploadButton');
+    const fileError = document.getElementById('fileError');
+    const allowedTypes = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'heif', 'pdf'];
+
+    //Validating dropped file
+    function validateFile(file) {
+        const fileExtension = file.name.split('.').pop().toLowerCase();
+        if (!allowedTypes.includes(fileExtension)) {
+            uploadButton.disabled = true;
+            fileError.style.display = 'block';
+            fileInput.value = ''; // Clear the file input
+            return false;
+        }
+        uploadButton.disabled = false;
+        fileError.style.display = 'none';
+        return true;
+    }
+
+    // Prevent default drag behaviors
+    ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+        document.addEventListener(eventName, preventDefaults, false);
+    });
+
+    function preventDefaults(e) {
+        e.preventDefault();
+        e.stopPropagation();
+    }
+
+    // Changing the Opacity for better visual
+    ['dragenter', 'dragover'].forEach(eventName => {
+        document.addEventListener(eventName, highlight, false);
+    });
+
+    ['dragleave', 'drop'].forEach(eventName => {
+        document.addEventListener(eventName, unhighlight, false);
+    });
+
+    function highlight(e) {
+        document.body.style.opacity = '0.7';
+        document.body.style.transition = 'opacity 0.2s ease';
+    }
+
+    function unhighlight(e) {
+        document.body.style.opacity = '1';
+    }
+
+    document.addEventListener('drop', function(e) {
+        const dt = e.dataTransfer;
+        const files = dt.files;
+
+        if (files.length > 0) {
+            const file = files[0];
+            if (validateFile(file)) {
+                // Update the file input with the dropped file
+                fileInput.files = files;
+                
+                // Show upload form if hidden
+                const uploadForm = document.getElementById('uploadForm');
+                if (uploadForm.style.display === 'none' || uploadForm.style.display === '') {
+                    uploadForm.style.display = 'block';
+                }
+            }
+        }
+    });
+});

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -65,7 +65,7 @@
     </div>
 
     <div class="button-container">
-        <button class="toggle" onclick="toggleUploadForm()">Upload Images</button>
+        <button class="toggle" onclick="toggleUploadForm()">Click to Upload or Drag & Drop Anywhere</button>
         <button class="logout-button"><a href="{{ url_for('logout') }}">Logout</a></button>
     </div>
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -57,6 +57,7 @@
         }
 
     </script>
+    <script src="{{ url_for('static', filename='js/dragdrop.js') }}"></script>
 </head>
 <body>
     <div class="nav">


### PR DESCRIPTION
This PR implements a page-wide drag and drop feature for file uploads, enhancing the user experience while maintaining existing file validation logic and upload mechanisms while maintaining compatibility with current functionality.

## Changes:
- New `dragdrop.js` handling drag-drop logic
- Added script reference in `profile.html`
- Maintains compatibility with current upload route in `app.py` 

## Testing:
- Validated file type restrictions `(.jpg, .jpeg, .png, .gif, .webp, .heif, .pdf)`
- Verified error message display for invalid files
- Tested DataTransfer object handling across different drop zones
- Cross-tested with existing manual upload functionality

### While uploading a valid format:

https://github.com/user-attachments/assets/ee627ec8-da23-4d2f-9fa9-5b5325321226

### While uploading an Invalid format:


https://github.com/user-attachments/assets/cc564eaa-8762-4544-9b90-969e666f6d25







**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)