### PR TITLE
Enhancement: Enable users to listen to their own uploaded voice notes

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import pathlib
 import re
 import sys
 from tkinter import ALL
-from flask import Flask, abort, render_template, request, redirect, url_for, flash, session, jsonify
+from flask import Flask, abort, render_template, request, redirect, url_for, flash, session, jsonify, send_from_directory
 from bson import ObjectId
 from google_auth_oauthlib.flow import Flow
 import requests
@@ -236,7 +236,11 @@ def edit_image(image_id):
     else:
         flash('Please log in to edit images.', 'danger')
         return redirect(url_for('login'))
-    
+ 
+@app.route('/audio/<filename>')
+def serve_audio(filename):
+    return send_from_directory(app.config['UPLOAD_FOLDER'], filename)
+   
 # Delete images uploaded by the user
 @app.route('/delete/<image_id>')
 def delete_image_route(image_id):

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -258,7 +258,12 @@ function handleUpload(event) {
                  onclick="previewImage(this.src, 'image')" 
                  style="cursor: pointer;">
             {%endif%}
-
+            {% if image.audio_filename %}
+                <audio controls style="width: 100%; max-width: 260px;">
+                    <source src="{{ url_for('serve_audio', filename=image.audio_filename) }}" type="audio/wav">
+                    Your browser does not support the audio element.
+                </audio>
+            {% endif %}
             <h3>{{ image.title }}</h3>
             <p>{{ image.description }}</p>
             <button class="more-info-button" onclick="toggleMoreInfo('{{ image.id }}')">More Info</button>


### PR DESCRIPTION
The current implementation don't have a feature for users to listen to their own recordings after uploading. The audio file is not accessible on the profile page, leading to a missing playback option.
**This PR introduces an embedded audio player in the user profile, allowing users to play their uploaded voice notes,
solving #77** 

## Changes:

- Added a new route to serve the uploaded audio files, in the backend```app.py```
- Frontend ```(profile.html):``` Integrated an HTML5 ```<audio>``` player below each uploaded image, displaying it only when a voice note exists.
- Styling Adjustments: Ensured the audio player fits within the image card layout for a clean UI.

## Screenshot:
![Att01](https://github.com/user-attachments/assets/46edc02d-6564-473b-96e6-e2241ec0eb89)

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)