### PR TITLE
Add download button for users and admin

### DIFF
--- a/app.py
+++ b/app.py
@@ -219,21 +219,16 @@ def generate_pdf_thumbnail(pdf_path, filename):
     thumbnails_dir = os.path.join(app.config['UPLOAD_FOLDER'], 'thumbnails')
     os.makedirs(thumbnails_dir, exist_ok=True) 
 
-    # Open the PDF file
     pdf_document = fitz.open(pdf_path)
     
-    # Get the first page
     first_page = pdf_document.load_page(0)
     
-    # Render the page to an image (zoom factor controls resolution)
     zoom = 2  # Increase for higher resolution
     mat = fitz.Matrix(zoom, zoom)
     pix = first_page.get_pixmap(matrix=mat)
     
-    # Convert to a PIL Image
     image = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
     
-    # Save the thumbnail
     thumbnail_filename = filename.replace('.pdf', '.jpg')
     thumbnail_path = os.path.join(thumbnails_dir, thumbnail_filename)
     image.save(thumbnail_path, 'JPEG')

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -607,3 +607,64 @@ h2{
     stroke: #08ca08;
     stroke-dasharray: 100 0;
 }
+
+/* donwload button */
+.button {
+    position: relative;
+    margin-left: 20px;
+    width: 150px;
+    height: 40px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    border: 1px solid #17795E;
+    background-color: #209978;
+    overflow: hidden;
+  }
+  
+  .button, .button__icon, .button__text {
+    transition: all 0.3s;
+  }
+  
+  .button .button__text {
+    transform: translateX(22px);
+    color: #fff;
+    font-weight: 600;
+  }
+  
+  .button .button__icon {
+    position: absolute;
+    transform: translateX(109px);
+    height: 100%;
+    width: 39px;
+    background-color: #17795E;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .button .svg {
+    width: 20px;
+    fill: #fff;
+  }
+  
+  .button:hover {
+    background: #17795E;
+  }
+  
+  .button:hover .button__text {
+    color: transparent;
+  }
+  
+  .button:hover .button__icon {
+    width: 148px;
+    transform: translateX(0);
+  }
+  
+  .button:active .button__icon {
+    background-color: #146c54;
+  }
+  
+  .button:active {
+    border: 1px solid #146c54;
+  }

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -278,6 +278,15 @@ function handleUpload(event) {
                     </form>
                 </div><br><br>
                 <a href="{{ url_for('delete_image_route', image_id=image.id) }}" class="delete-button">Delete</a>
+                <br><br>
+                <a href="{{ url_for('static', filename='uploads/' ~ image.filename) }}" 
+                download="{{ image.filename }}" 
+                class="download-button">
+                    <button class="button" type="button">
+                        <span class="button__text">Download</span>
+                        <span class="button__icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 35 35" id="bdd05811-e15d-428c-bb53-8661459f9307" data-name="Layer 2" class="svg"><path d="M17.5,22.131a1.249,1.249,0,0,1-1.25-1.25V2.187a1.25,1.25,0,0,1,2.5,0V20.881A1.25,1.25,0,0,1,17.5,22.131Z"></path><path d="M17.5,22.693a3.189,3.189,0,0,1-2.262-.936L8.487,15.006a1.249,1.249,0,0,1,1.767-1.767l6.751,6.751a.7.7,0,0,0,.99,0l6.751-6.751a1.25,1.25,0,0,1,1.768,1.767l-6.752,6.751A3.191,3.191,0,0,1,17.5,22.693Z"></path><path d="M31.436,34.063H3.564A3.318,3.318,0,0,1,.25,30.749V22.011a1.25,1.25,0,0,1,2.5,0v8.738a.815.815,0,0,0,.814.814H31.436a.815.815,0,0,0,.814-.814V22.011a1.25,1.25,0,1,1,2.5,0v8.738A3.318,3.318,0,0,1,31.436,34.063Z"></path></svg></span>
+                    </button>
+                </a>
             </div>
         </div>
         {% endfor %}

--- a/templates/user_images.html
+++ b/templates/user_images.html
@@ -128,6 +128,15 @@
                     </form>
                 </div><br><br>
                 <a href="{{ url_for('delete_image_route', image_id=image.id) }}" class="delete-button">Delete</a>
+                <br><br>
+                <a href="{{ url_for('static', filename='uploads/' ~ image.filename) }}" 
+                download="{{ image.filename }}" 
+                class="download-button">
+                    <button class="button" type="button">
+                        <span class="button__text">Download</span>
+                        <span class="button__icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 35 35" id="bdd05811-e15d-428c-bb53-8661459f9307" data-name="Layer 2" class="svg"><path d="M17.5,22.131a1.249,1.249,0,0,1-1.25-1.25V2.187a1.25,1.25,0,0,1,2.5,0V20.881A1.25,1.25,0,0,1,17.5,22.131Z"></path><path d="M17.5,22.693a3.189,3.189,0,0,1-2.262-.936L8.487,15.006a1.249,1.249,0,0,1,1.767-1.767l6.751,6.751a.7.7,0,0,0,.99,0l6.751-6.751a1.25,1.25,0,0,1,1.768,1.767l-6.752,6.751A3.191,3.191,0,0,1,17.5,22.693Z"></path><path d="M31.436,34.063H3.564A3.318,3.318,0,0,1,.25,30.749V22.011a1.25,1.25,0,0,1,2.5,0v8.738a.815.815,0,0,0,.814.814H31.436a.815.815,0,0,0,.814-.814V22.011a1.25,1.25,0,1,1,2.5,0v8.738A3.318,3.318,0,0,1,31.436,34.063Z"></path></svg></span>
+                    </button>
+                </a>
             </div>
         </div>
         {% endfor %}


### PR DESCRIPTION
solves issue #54 
**Description of your changes:**
Added a download button with a interactive UI for enhancing user experience. for users as well as admins.
Ensured easy retrieval of images or pdfs for admins as well as users

https://github.com/user-attachments/assets/09d2b553-9722-46e0-98eb-44796ccc181c



**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)