### PR TITLE
Add Contribution Guidelines for Active Branches in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ If you want to run this project locally, See the [setup.md](DOCS/setup.md).
 
 If you like to contribute on our project, See the [contributing.md](DOCS/contributing.md).
 
+> **NOTE:**  
+> We currently have **two active branches** for development:  
+>  
+> - **`modular` Branch** – Focused on modularizing the codebase.  
+> - **`dev` Branch** – General development and feature updates.  
+>  
+> You are welcome to contribute to **either of these branches** based on your interest.  
+> However, please note that the **`main` branch is frozen for now** and not open for direct contributions.  
+
 
 
 ## License


### PR DESCRIPTION
New contributors often open PRs to the `main` branch due to a lack of prior knowledge. To prevent this, I have added a note in the `README.md` file, clarifying that contributions should be made to either the `modular` or `dev` branch, while the `main` branch remains frozen.  
This will help guide contributors in advance and reduce PRs to the wrong branch. 

**Checklist:**
- [ ] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)