### PR TITLE
Implement "Remember Me" and Session Management

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -13,9 +13,16 @@
         <input type="password" id="password" name="password" placeholder="Password" required>
         <span id="togglePassword" style="position: absolute; right: 10px; top: 30px; cursor: pointer; font-size: 20px; user-select: none;">👁️</span>
     </div>
-    <a href="{{ url_for('forgot_password') }}">Forgot Password?</a>
+    
+    <div style="display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; margin-bottom: 10px;">
+      <label for="remember_me" style="margin: 0;">Remember Me</label>
+      <input type="checkbox" id="remember_me" name="remember_me" style="margin: 0;">
+    </div>  
     
     <button type="submit">Login</button>
+    <div style="margin-top: 10px;">
+      <a href="{{ url_for('forgot_password') }}">Forgot Password?</a>
+    </div>
 </form>
 
 <div class="google-signin">
@@ -48,6 +55,12 @@
         });
       } else {
         console.log('Toggle password elements not found');
+      }
+      
+      // Auto-check "Remember Me" for mobile users
+      const rememberMeCheckbox = document.getElementById('remember_me');
+      if (rememberMeCheckbox && (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent))) {
+        rememberMeCheckbox.checked = true;
       }
     });
   </script>


### PR DESCRIPTION
The PR adds "Remember Me" Feature on Login Page. Now:

- Users can stay logged in for 30 days if they check "Remember Me" while logging in.
- If checked, visiting ```/login``` will redirect to the profile page instead of asking for credentials again.
- If unchecked, users must re-enter their password on returning.
- Mobile users will have this option enabled by default (as per @pradeeban 's suggestion ).

## Screenshot:
![image](https://github.com/user-attachments/assets/7ba9671e-c447-43a8-9768-5f58999d93b3)


**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)