### PR TITLE
Add User Attribution & standard Audio Player

### DIFF
--- a/templates/user_images.html
+++ b/templates/user_images.html
@@ -90,7 +90,7 @@
     </script>
 </head>
 <body>
-    <h2 style="text-align: center;">Uploaded Images</h2>
+    <h2 style="text-align: center;">Uploaded Images by @{{ username }}</h2>
     <div class="image-container">
         {% for image in images %}
         <div class="image-card">

--- a/templates/user_images.html
+++ b/templates/user_images.html
@@ -111,9 +111,10 @@
             <!-- Speaker Icon for Audio -->
             {% set audio_path = url_for('static', filename='uploads/' ~ image.audio_filename) %}
             {% if image.audio_filename %}
-            <button class="speaker-button" onclick="playAudio('{{ audio_path }}')">
-             🔊
-            </button>
+            <audio controls class="audio-player" style="width: 100%; margin-top: 5px;">
+                <source src="{{ audio_path }}" type="audio/mpeg">
+                Your browser does not support the audio element.
+            </audio>
             {% endif %}
             <h3>{{ image.title }}</h3>
             <p>{{ image.description }}</p>


### PR DESCRIPTION
This PR adds user attribution for uploaded images, ensuring proper credit is shown. It also upgrades the basic audio controls to a standard HTML5 audio player with playback controls (play/pause), the ability to jump to specific parts of the audio, volume adjustment, and a native download option. Previously, the download button only supported images and PDFs, so this update improves the existing feature.

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)