### PR TITLE
Add File Selection Button with Visible Filename Display

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -1027,3 +1027,42 @@ input {
     font-weight: bold; 
     font-family: Arial, sans-serif; 
   }
+
+.file-selection-area {
+    margin-bottom: 15px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.file-button {
+    width: 0.1px;
+    height: 0.1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: -1;
+}
+
+.file-select-button {
+    background-color: #4caf50;
+    color: white;
+    padding: 10px 15px;
+    border-radius: 4px;
+    cursor: pointer;
+    display: inline-block;
+    margin-right: 10px;
+    transition: background-color 0.3s;
+}
+
+.file-select-button:hover {
+    background-color: #45a049;
+}
+
+.selected-files {
+    flex: 1;
+    padding: 5px 10px;
+    margin-top: 5px;
+    color: #666;
+    font-style: italic;
+}

--- a/static/js/dragdrop.js
+++ b/static/js/dragdrop.js
@@ -46,6 +46,22 @@ document.addEventListener('DOMContentLoaded', function() {
         document.body.style.opacity = '1';
     }
 
+    // Update file name display function
+    function updateFileNameDisplay() {
+        const selectedFiles = document.getElementById('selectedFiles');
+        if (selectedFiles) {
+            if (fileInput.files.length > 0) {
+                if (fileInput.files.length === 1) {
+                    selectedFiles.textContent = fileInput.files[0].name;
+                } else {
+                    selectedFiles.textContent = fileInput.files.length + ' files selected';
+                }
+            } else {
+                selectedFiles.textContent = 'No file chosen';
+            }
+        }
+    }
+
     document.addEventListener('drop', function(e) {
         const dt = e.dataTransfer;
         const files = dt.files;
@@ -55,6 +71,9 @@ document.addEventListener('DOMContentLoaded', function() {
             if (validateFile(file)) {
                 // Update the file input with the dropped file
                 fileInput.files = files;
+                
+                // Update the file name display
+                updateFileNameDisplay();
                 
                 // Show upload form if hidden
                 const uploadForm = document.getElementById('uploadForm');

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -192,6 +192,21 @@ function handleUpload(event) {
     }, 2000); 
 }
 
+function updateFileLabel() {
+    const fileInput = document.getElementById('fileInput');
+    const fileLabel = document.getElementById('selectedFiles');
+    
+    if (fileInput.files.length > 0) {
+        if (fileInput.files.length === 1) {
+            fileLabel.textContent = fileInput.files[0].name;
+        } else {
+            fileLabel.textContent = fileInput.files.length + ' files selected';
+        }
+    } else {
+        fileLabel.textContent = 'No file chosen';
+    }
+}
+
 //function for fetching sentiments from sentiment.json
 fetch("{{ url_for('static', filename='sentiments.json') }}")
         .then(response => response.json())
@@ -235,6 +250,15 @@ fetch("{{ url_for('static', filename='sentiments.json') }}")
         });
     </script>
 
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const fileInput = document.getElementById('fileInput');
+            if (fileInput) {
+                fileInput.addEventListener('change', updateFileLabel);
+            }
+        });
+    </script>
+
 </head>
 <body>
  
@@ -273,20 +297,23 @@ fetch("{{ url_for('static', filename='sentiments.json') }}")
     <div class="toggle-container">
         <div id="uploadForm" style="display: none;">
             <form action="{{ url_for('upload_images') }}" method="post" enctype="multipart/form-data" id="upload-form">
-                <input class="file-button" type="file" name="files" id="fileInput" multiple accept=".jpg,.jpeg,.png,.gif,.webp,.heif,.pdf" required onchange="validateFile(this)"><br>            
+                <div class="file-selection-area">
+                    <input class="file-button" type="file" name="files" id="fileInput" multiple accept=".jpg,.jpeg,.png,.gif,.webp,.heif,.pdf" required onchange="validateFile(this)">
+                    <label for="fileInput" class="file-select-button">Select Files</label>
+                    <span class="selected-files" id="selectedFiles">No file chosen</span>
+                </div>
                 <input class="title-area" type="text" name="title" placeholder="Title" required><br>
                 <textarea class="description-area" name="description" placeholder="Description" required></textarea><br>
                 <label for="sentiment" class="dropdown-label">Select Sentiment with which you are uploading the image:</label>
                 <select name="sentiment" id="sentiment" required class="dropdown">
-                 <option value="" disabled selected>Choose a Sentiment</option>
+                    <option value="" disabled selected>Choose a Sentiment</option>
                 </select>
-               
                 
                 <button type="button" onclick="startRecording()" class="record-btn">Start Recording</button>
                 <button type="button" onclick="stopRecording()" class="stop-btn" disabled id="stopBtn">Stop Recording</button>
                 <button type="button" onclick="resetRecording()" id="resetBtn" class="reset-btn" style="display: none;"> Reset Recording</button>
                 <audio id="audioPlayback" controls style="display: none;"></audio>
-    
+        
                 <input type="hidden" name="audioData" id="audioData">
                 <button class="uploadButton" id="uploadButton" type="submit" onclick="handleUpload(event)">
                     <svg xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
This PR improves the upload experience by adding a "Select File" button alongside drag-and-drop. It also displays the selected filename, providing clear user feedback. Thus solving issue #150 

## Screenshot:
![Screenshot from 2025-03-20 01-43-09](https://github.com/user-attachments/assets/cdda6927-d355-49ae-810e-a58b4effd9e5)


**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)