### PR TITLE
Implement Multiple Sentiment Selection with Custom Input

### DIFF
--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -1064,5 +1064,61 @@ input {
     padding: 5px 10px;
     margin-top: 5px;
     color: #666;
-    font-style: italic;
+    font-style: Arial;
+}
+
+.sentiment-selector {
+    display: flex;
+    margin-bottom: 10px;
+}
+
+.add-sentiment-btn {
+    margin-left: 10px;
+    padding: 0px 10px;
+    height: 40px;
+    background: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 10px;
+    cursor: pointer;
+}
+
+.selected-sentiments-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.sentiment-tag {
+    display: flex;
+    align-items: center;
+    background: #e1e1e1;
+    padding: 5px 10px;
+    border-radius: 20px;
+    margin-right: 5px;
+    margin-bottom: 5px;
+}
+
+.sentiment-tag .move-btn {
+    cursor: pointer;
+    margin: 0 5px;
+    font-size: 14px;
+}
+
+.sentiment-tag .delete-sentiment {
+    cursor: pointer;
+    color: #ff4d4d;
+    margin-left: 8px;
+}
+
+.custom-sentiment-area {
+    height: 60px;
+    margin-bottom: 15px;
+    width: 100%;
+}
+
+.custom-sentiment-container {
+    margin-top: 10px;
+    width: 100%;
 }

--- a/static/sentiments.json
+++ b/static/sentiments.json
@@ -1,6 +1,6 @@
 {
     "sentiments": [
-        "Cannot Decide",
+        "Decide Later",
         "Joyful",
         "Melancholic",
         "Hopeful",

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -182,12 +182,6 @@ function handleUpload(event) {
     
     const customSentiment = document.getElementById('custom-sentiment').value.trim();
 
-    // Check if at least one sentiment is selected or custom sentiment is provided
-    if (selectedSentiments.length === 0 && !customSentiment) {
-        alert("Please select at least one sentiment or provide a custom sentiment");
-        return;
-    }
-
     // Update the hidden input to ensure custom sentiment is included
     updateHiddenInput();
 
@@ -237,8 +231,6 @@ fetch("{{ url_for('static', filename='sentiments.json') }}")
 let selectedSentiments = [];
 
 document.addEventListener('DOMContentLoaded', function() {
-    // Fetch sentiments for the dropdown (you already have this)
-    
     // Add event listener for the Add button
     document.getElementById('add-sentiment').addEventListener('click', function() {
         const dropdown = document.getElementById('sentiment-dropdown');
@@ -250,7 +242,7 @@ document.addEventListener('DOMContentLoaded', function() {
             updateHiddenInput();
         }
     });
-    // Initialize the hidden input
+    // Initialise the hidden input
     updateHiddenInput();
     // Add event listener for custom sentiment changes
     document.getElementById('custom-sentiment').addEventListener('input', function() {

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -179,11 +179,23 @@ function handleUpload(event) {
 
     let button = document.getElementById("uploadButton");
     let form = document.getElementById("upload-form");
+    
+    const customSentiment = document.getElementById('custom-sentiment').value.trim();
+
+    // Check if at least one sentiment is selected or custom sentiment is provided
+    if (selectedSentiments.length === 0 && !customSentiment) {
+        alert("Please select at least one sentiment or provide a custom sentiment");
+        return;
+    }
+
+    // Update the hidden input to ensure custom sentiment is included
+    updateHiddenInput();
 
     if (!form.checkValidity()) {
         form.reportValidity(); 
         return; 
     }
+    
     button.classList.add("active");
 
     setTimeout(() => {
@@ -209,17 +221,115 @@ function updateFileLabel() {
 
 //function for fetching sentiments from sentiment.json
 fetch("{{ url_for('static', filename='sentiments.json') }}")
-        .then(response => response.json())
-        .then(data => {
-            const sentimentDropdown = document.getElementById("sentiment");
-            data.sentiments.forEach(sentiment => {
-                let option = document.createElement("option");
-                option.value = sentiment;
-                option.textContent = sentiment;
-                sentimentDropdown.appendChild(option);
-            });
-        })
-        .catch(error => console.error("Error loading sentiments:", error));
+    .then(response => response.json())
+    .then(data => {
+        const sentimentDropdown = document.getElementById("sentiment-dropdown");
+        data.sentiments.forEach(sentiment => {
+            let option = document.createElement("option");
+            option.value = sentiment;
+            option.textContent = sentiment;
+            sentimentDropdown.appendChild(option);
+        });
+    })
+    .catch(error => console.error("Error loading sentiments:", error));
+
+// Initialize the selected sentiments array
+let selectedSentiments = [];
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Fetch sentiments for the dropdown (you already have this)
+    
+    // Add event listener for the Add button
+    document.getElementById('add-sentiment').addEventListener('click', function() {
+        const dropdown = document.getElementById('sentiment-dropdown');
+        const selectedValue = dropdown.value;
+        
+        if (selectedValue && !selectedSentiments.includes(selectedValue)) {
+            selectedSentiments.push(selectedValue);
+            updateSelectedSentimentsUI();
+            updateHiddenInput();
+        }
+    });
+    // Initialize the hidden input
+    updateHiddenInput();
+    // Add event listener for custom sentiment changes
+    document.getElementById('custom-sentiment').addEventListener('input', function() {
+        updateHiddenInput();
+    });
+});
+
+function updateSelectedSentimentsUI() {
+    const container = document.getElementById('selected-sentiments');
+    container.innerHTML = '';
+    
+    selectedSentiments.forEach((sentiment, index) => {
+        const tag = document.createElement('div');
+        tag.className = 'sentiment-tag';
+        
+        // Add move left button (except for first item)
+        if (index > 0) {
+            const moveLeft = document.createElement('span');
+            moveLeft.className = 'move-btn';
+            moveLeft.innerHTML = '&larr;';
+            moveLeft.onclick = function() {
+                moveSentiment(index, index - 1);
+            };
+            tag.appendChild(moveLeft);
+        }
+        
+        // Add sentiment text
+        const text = document.createElement('span');
+        text.textContent = sentiment;
+        tag.appendChild(text);
+        
+        // Add move right button (except for last item)
+        if (index < selectedSentiments.length - 1) {
+            const moveRight = document.createElement('span');
+            moveRight.className = 'move-btn';
+            moveRight.innerHTML = '&rarr;';
+            moveRight.onclick = function() {
+                moveSentiment(index, index + 1);
+            };
+            tag.appendChild(moveRight);
+        }
+        
+        // Add delete button
+        const deleteBtn = document.createElement('span');
+        deleteBtn.className = 'delete-sentiment';
+        deleteBtn.innerHTML = '&times;';
+        deleteBtn.onclick = function() {
+            selectedSentiments.splice(index, 1);
+            updateSelectedSentimentsUI();
+            updateHiddenInput();
+        };
+        tag.appendChild(deleteBtn);
+        
+        container.appendChild(tag);
+    });
+}
+
+function moveSentiment(fromIndex, toIndex) {
+    const item = selectedSentiments[fromIndex];
+    selectedSentiments.splice(fromIndex, 1);
+    selectedSentiments.splice(toIndex, 0, item);
+    updateSelectedSentimentsUI();
+    updateHiddenInput();
+}
+
+function updateHiddenInput() {
+    let selectedSentimentsStr = selectedSentiments.join(', ');
+    
+    // Gets custom sentiment if entered
+    const customSentiment = document.getElementById('custom-sentiment').value.trim();
+    
+    // Adds custom sentiment to the value if user inputs
+    if (customSentiment) {
+        document.getElementById('sentiment-input').value = selectedSentimentsStr + 
+            (selectedSentimentsStr ? '; Custom: ' : 'Custom: ') + customSentiment;
+    } else {
+        document.getElementById('sentiment-input').value = selectedSentimentsStr;
+    }
+}
     </script>
     <script src="{{ url_for('static', filename='js/dragdrop.js') }}"></script>
 
@@ -304,10 +414,21 @@ fetch("{{ url_for('static', filename='sentiments.json') }}")
                 </div>
                 <input class="title-area" type="text" name="title" placeholder="Title" required><br>
                 <textarea class="description-area" name="description" placeholder="Description" required></textarea><br>
-                <label for="sentiment" class="dropdown-label">Select Sentiment with which you are uploading the image:</label>
-                <select name="sentiment" id="sentiment" required class="dropdown">
-                    <option value="" disabled selected>Choose a Sentiment</option>
-                </select>
+                <label class="dropdown-label">Select Sentiments for your image:</label>
+                <div class="sentiment-selector">
+                    <select id="sentiment-dropdown" class="dropdown">
+                        <option value="" disabled selected>Choose a Sentiment</option>
+                    </select>
+                    <button type="button" id="add-sentiment" class="add-sentiment-btn">Add</button>
+                </div>
+                <div id="selected-sentiments" class="selected-sentiments-container">
+                    <!-- Selected sentiments will appear here -->
+                </div>
+                <div class="custom-sentiment-container">
+                    <label for="custom-sentiment" class="dropdown-label">Custom Sentiment:</label>
+                    <textarea id="custom-sentiment" name="custom_sentiment" class="description-area custom-sentiment-area" placeholder="Describe your own feelings or emotions about this image..."></textarea>
+                </div>
+                <input type="hidden" name="sentiment" id="sentiment-input" required>
                 
                 <button type="button" onclick="startRecording()" class="record-btn">Start Recording</button>
                 <button type="button" onclick="stopRecording()" class="stop-btn" disabled id="stopBtn">Stop Recording</button>


### PR DESCRIPTION
This PR implements an enhanced sentiment selection system allowing users to:

- select multiple sentiments from the drop down option and an "Add" button to append selected sentiments.
- Allowing rearrange and delete selected sentiments while uploading.
- Add custom sentiments via a dedicated text input field (Storing it in the same sentiment attribute in the user database)
- changed selected files text font to Arial.

the selected sentiments a re separated by comas along with the custom sentiments in the database:
![image](https://github.com/user-attachments/assets/a1a21265-6bd3-4ada-b9e2-8fa08ac75bbc)

 

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)