### PR TITLE
Add Sentiment Editing Functionality for Admins and Users

### DIFF
--- a/Database/userdatahandler.py
+++ b/Database/userdatahandler.py
@@ -168,8 +168,20 @@ def get_images_by_user(username):
     return [{'id': str(image['_id']), 'filename': image['filename'], 'title': image['title'], 'description': image['description'], 'audio_filename': image.get('audio_filename', ""), 'sentiment':image.get('sentiment', "")} for image in images]
 
 # Update image in MongoDB
-def update_image(image_id, title, description):
-    beehive_image_collection.update_one({'_id': image_id}, {'$set': {'title': title, 'description': description}})
+def update_image(image_id, title, description, sentiment=None):
+    update_data = {
+        'title': title, 
+        'description': description
+    }
+    
+    # Only include sentiment in the update if it is provided by the user
+    if sentiment is not None:
+        update_data['sentiment'] = sentiment
+        
+    beehive_image_collection.update_one(
+        {'_id': image_id}, 
+        {'$set': update_data}
+    )
 
 # Delete image from MongoDB
 def delete_image(image_id):

--- a/app.py
+++ b/app.py
@@ -519,6 +519,7 @@ def edit_image(image_id):
     if 'username' in session or 'google_id' in session:
         title = request.form['title']
         description = request.form['description']
+        sentiment = request.form.get('sentiment', '')
 
         try:
             image_id = ObjectId(image_id)
@@ -526,7 +527,7 @@ def edit_image(image_id):
             flash(f'Invalid image ID format: {str(e)}', 'danger')
             return redirect(url_for('profile'))
 
-        update_image(image_id, title, description)
+        update_image(image_id, title, description, sentiment)
         flash('Image updated successfully!', 'success')
         if 'username' in session:
             return redirect(url_for('profile'))

--- a/app.py
+++ b/app.py
@@ -520,20 +520,21 @@ def edit_image(image_id):
         title = request.form['title']
         description = request.form['description']
         sentiment = request.form.get('sentiment', '')
+        
+        # Get the referrer URL to return to the same page
+        referrer = request.referrer or url_for('profile')
 
         try:
             image_id = ObjectId(image_id)
         except Exception as e:
             flash(f'Invalid image ID format: {str(e)}', 'danger')
-            return redirect(url_for('profile'))
+            return redirect(referrer)
 
         update_image(image_id, title, description, sentiment)
         flash('Image updated successfully!', 'success')
-        if 'username' in session:
-            return redirect(url_for('profile'))
-        elif 'google_id' in session:
-            return redirect(url_for('getallusers'))
-        return redirect(url_for('login'))
+        
+        # Redirect back to the page that submitted the form
+        return redirect(referrer)
     else:
         flash('Please log in to edit images.', 'danger')
         return redirect(url_for('login'))

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -472,8 +472,15 @@ function updateHiddenInput() {
                 <button class="edit-button" onclick="toggleEditForm('{{ image.id }}')">Edit</button>
                 <div id="editForm_{{ image.id }}" class="edit-form" style="display: none;"><br><br>
                     <form action="{{ url_for('edit_image', image_id=image.id) }}" class="edit-form" method="post">
-                        <input type="text" name="title" value="{{ image.title }}" class="text-input" required>
-                        <textarea name="description" class="text-input" required>{{ image.description }}</textarea>
+                        <label for="title_{{ image.id }}">Title:</label>
+                        <input type="text" id="title_{{ image.id }}" name="title" value="{{ image.title }}" class="text-input" required>
+                        
+                        <label for="description_{{ image.id }}">Description:</label>
+                        <textarea id="description_{{ image.id }}" name="description" class="text-input" required>{{ image.description }}</textarea>
+                        
+                        <label for="sentiment_{{ image.id }}">Sentiment:</label>
+                        <textarea id="sentiment_{{ image.id }}" name="sentiment" class="text-input">{{ image.sentiment }}</textarea>
+                        
                         <button type="submit" class="update-button">Update</button>
                     </form>
                 </div><br><br>

--- a/templates/user_images.html
+++ b/templates/user_images.html
@@ -123,10 +123,17 @@
             <div id="moreInfo_{{ image.id }}" class="more-info" style="display: none;">
                 <button class="edit-button" onclick="toggleEditForm('{{ image.id }}')">Edit</button>
                 <div id="editForm_{{ image.id }}" class="edit-form" style="display: none;"><br><br>
-                    <form action="{{ url_for('edit_image', image_id=image.id) }}" method="post">
-                        <input type="text" name="title" value="{{ image.title }}" required>
-                        <textarea name="description" required>{{ image.description }}</textarea>
-                        <button type="submit">Update</button>
+                    <form action="{{ url_for('edit_image', image_id=image.id) }}" class="edit-form" method="post">
+                        <label for="title_{{ image.id }}">Title:</label>
+                        <input type="text" id="title_{{ image.id }}" name="title" value="{{ image.title }}" class="text-input" required>
+                        
+                        <label for="description_{{ image.id }}">Description:</label>
+                        <textarea id="description_{{ image.id }}" name="description" class="text-input" required>{{ image.description }}</textarea>
+                        
+                        <label for="sentiment_{{ image.id }}">Sentiment:</label>
+                        <textarea id="sentiment_{{ image.id }}" name="sentiment" class="text-input">{{ image.sentiment }}</textarea>
+                        
+                        <button type="submit" class="update-button">Update</button>
                     </form>
                 </div><br><br>
                 <a href="{{ url_for('delete_image_route', image_id=image.id) }}" class="delete-button">Delete</a>


### PR DESCRIPTION
This PR adds the option for Admins and users to edit sentiment data for their uploads (In addition to Title and Description)  as discussed in #184 .Changes are:
- Modified update_image() function in userdatahandler.py to accept and process sentiment data
- Updated the edit form in profile.html to include sentiment field and added labelling.
- Updated the edit route to pass sentiment data to the database.
- Aditionally, admins were sent to admin/users page after any updates (maybe due to login type). So I have used "referrer" which is the page user came from. Now after pressing "Update", Admins stay on the same page and can see their changes there.

## Now the Edit Form looks like this,which open up when we click "Edit":
![Screenshot from 2025-03-30 08-06-15](https://github.com/user-attachments/assets/66f2cc70-227a-4d1e-8120-32f67035d480)

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/DOCS/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)