### PR TITLE
Added filter functionality based on sentiments

### DIFF
--- a/Database/userdatahandler.py
+++ b/Database/userdatahandler.py
@@ -167,6 +167,29 @@ def get_images_by_user(username):
     images = beehive_image_collection.find({'username': username})
     return [{'id': str(image['_id']), 'filename': image['filename'], 'title': image['title'], 'description': image['description'], 'audio_filename': image.get('audio_filename', ""), 'sentiment':image.get('sentiment', "")} for image in images]
 
+# Get images by sentiments list from MongoDB
+def get_images_by_sentiments(username, sentiment_list, match_all):
+    if match_all:
+        # Match all tags (AND logic)
+        query = {
+            "username": username,
+            "$and": [{"sentiment": {"$regex": tag, "$options": "i"}} for tag in sentiment_list]
+        }
+    else:
+        # Match any tag (OR logic)
+        query = {
+            "username": username,
+            "$or": [{"sentiment": {"$regex": tag, "$options": "i"}} for tag in sentiment_list]
+        }
+
+    images = beehive_image_collection.find(query)
+    return [{'id': str(image['_id']), 
+             'filename': image['filename'], 
+             'title': image['title'], 
+             'description': image['description'], 
+             'audio_filename': image.get('audio_filename', ""), 
+             'sentiment': image.get('sentiment', "")} for image in images]
+
 # Update image in MongoDB
 def update_image(image_id, title, description, sentiment=None):
     update_data = {

--- a/app.py
+++ b/app.py
@@ -27,7 +27,8 @@ from Database.userdatahandler import (
     create_google_user,  
     delete_image,
     get_currentuser_from_session, 
-    get_image_by_id, 
+    get_image_by_id,
+    get_images_by_sentiments, 
     get_images_by_user, 
     get_password_by_username, 
     get_user_by_username,
@@ -381,8 +382,14 @@ def profile():
     if not user:
         flash('User not found.', 'danger')
         return redirect(url_for('login'))
+    tags = request.args.get('sentiments', '').strip()
+    match_all = request.args.get('match_all') == '1'
 
-    images = get_images_by_user(username)  # Fetch images uploaded by the user
+    if tags:
+      tag_list = [tag.strip().lower() for tag in tags.split(',') if tag.strip()]
+      images = get_images_by_sentiments(username, tag_list, match_all)
+    else:
+      images = get_images_by_user(username)  # Fetch images uploaded by the user
 
     return render_template(
         "profile.html", 

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -1126,11 +1126,7 @@ input {
     text-align: center;
     margin: 20px 0;
     padding: 10px;
-    background-color: #333;
-    border-radius: 8px;
-    color: white;
 }
-
 .filter-form {
     display: flex;
     flex-wrap: wrap;
@@ -1155,7 +1151,7 @@ input {
     background-color: #007bff;
     border: none;
     border-radius: 5px;
-    margin-top: -7px;
+    margin-top: -10px;
 }
 
 .filter-button:hover {
@@ -1167,9 +1163,8 @@ input {
 }
 
 label {
-    margin-top: -8px;
     font-size: 14px;
-    color: white;
+    color: #333;
 }
 
 input[type="checkbox"] {

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -1122,3 +1122,54 @@ input {
     margin-top: 10px;
     width: 100%;
 }
+.filter-container {
+    margin-left: auto;
+    background-color: #333;
+}
+
+.filter-form {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+}
+
+.filter-input {
+    width: 60%;
+    max-width: 400px;
+    padding: 10px;
+    font-size: 16px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+}
+
+.filter-button {
+    padding: 10px 20px;
+    font-size: 16px;
+    color: #fff;
+    background-color: #007bff;
+    border: none;
+    border-radius: 5px;
+    margin-top: -7px;
+}
+
+.filter-button:hover {
+    background-color: #0056b3;
+}
+
+.filter-button:active {
+    background-color: #004085;
+}
+
+label {
+    margin-top: -8px;
+    font-size: 14px;
+    color: white;
+}
+
+input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+}

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -1123,8 +1123,12 @@ input {
     width: 100%;
 }
 .filter-container {
-    margin-left: auto;
+    text-align: center;
+    margin: 20px 0;
+    padding: 10px;
     background-color: #333;
+    border-radius: 8px;
+    color: white;
 }
 
 .filter-form {

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -1165,6 +1165,13 @@ input {
 label {
     font-size: 14px;
     color: #333;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+}
+.match-label{
+  margin-top: -5px;
 }
 
 input[type="checkbox"] {

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -452,7 +452,7 @@ function updateHiddenInput() {
         <button type="submit" class="filter-button">Filter</button>
         <label>
             <input type="checkbox" name="match_all" value="1" {% if request.args.get('match_all') %}checked{% endif %}>
-            <span>Match All</span>
+            <span class="match-label">Match All</span>
         </label>
     </form>
   </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -446,7 +446,7 @@ function updateHiddenInput() {
     <h2 style="text-align: center;">Uploaded Images</h2>
     
     <div class="filter-container">
-      <h2>Filter images by sentiments</h2>
+      <h2>Filter Images by Sentiments</h2>
       <form action="{{ url_for('profile') }}" method="get" class="filter-form">
         <input type="text" name="sentiments" placeholder="Enter tags (comma-separated)" value="{{ request.args.get('sentiments', '') }}" class="filter-input">
         <button type="submit" class="filter-button">Filter</button>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -368,16 +368,7 @@ function updateHiddenInput() {
 <div class="nav">
     <img src = "{{url_for('static', filename='Logo.svg')}}" alt="Beehive Logo" class="logo">
     <div class="heading">Beehive</div>
-    <div class="filter-container">
-      <form action="{{ url_for('profile') }}" method="get" class="filter-form">
-        <input type="text" name="sentiments" placeholder="Enter tags (comma-separated)" value="{{ request.args.get('sentiments', '') }}" class="filter-input">
-        <button type="submit" class="filter-button">Filter</button>
-        <label>
-            <input type="checkbox" name="match_all" value="1" {% if request.args.get('match_all') %}checked{% endif %}>
-            <span>Match All</span>
-        </label>
-    </form>
-  </div>
+    
 
     <!-- <h1>{{ username }}</h1> -->
     <div class="profile-photo-container" id="profile-photo-container">
@@ -454,6 +445,17 @@ function updateHiddenInput() {
 
     <h2 style="text-align: center;">Uploaded Images</h2>
     
+    <div class="filter-container">
+      <h2>Filter images by sentiments</h2>
+      <form action="{{ url_for('profile') }}" method="get" class="filter-form">
+        <input type="text" name="sentiments" placeholder="Enter tags (comma-separated)" value="{{ request.args.get('sentiments', '') }}" class="filter-input">
+        <button type="submit" class="filter-button">Filter</button>
+        <label>
+            <input type="checkbox" name="match_all" value="1" {% if request.args.get('match_all') %}checked{% endif %}>
+            <span>Match All</span>
+        </label>
+    </form>
+  </div>
     <div class="image-container">
         {% for image in images %}
         <div class="image-card">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -368,6 +368,17 @@ function updateHiddenInput() {
 <div class="nav">
     <img src = "{{url_for('static', filename='Logo.svg')}}" alt="Beehive Logo" class="logo">
     <div class="heading">Beehive</div>
+    <div class="filter-container">
+      <form action="{{ url_for('profile') }}" method="get" class="filter-form">
+        <input type="text" name="sentiments" placeholder="Enter tags (comma-separated)" value="{{ request.args.get('sentiments', '') }}" class="filter-input">
+        <button type="submit" class="filter-button">Filter</button>
+        <label>
+            <input type="checkbox" name="match_all" value="1" {% if request.args.get('match_all') %}checked{% endif %}>
+            <span>Match All</span>
+        </label>
+    </form>
+  </div>
+
     <!-- <h1>{{ username }}</h1> -->
     <div class="profile-photo-container" id="profile-photo-container">
         {% if user_dp %}
@@ -378,6 +389,7 @@ function updateHiddenInput() {
             </div>
         {% endif %}
     </div>
+    
 </div>
 
     {% with messages = get_flashed_messages(with_categories=true) %}
@@ -441,6 +453,7 @@ function updateHiddenInput() {
     </div>
 
     <h2 style="text-align: center;">Uploaded Images</h2>
+    
     <div class="image-container">
         {% for image in images %}
         <div class="image-card">


### PR DESCRIPTION
This PR is a new update of a previously issued PR that introduced a functionality to filter user-uploaded images based on custom tags. However, the new changes include:
- Users no longer have to rely solely on predefined tags, as they now have the ability to add custom sentiments.
- No need to add new attribute ( tags ) to the image object.
The feature allows users to filter images on their profile page by entering tags (sentiments) and optionally specifying whether all tags must match or any tag can match. The implementation includes updates to the backend, frontend, and database query logic to support this enhanced functionality.

# Key Changes:

1. Backend:
- Modified the profile route to handle filtering logic based on query parameters sentiments and match_all.
- Added new functionality to query images of user based on the filter parameters.
2. Frontend:
- Added a filter form to allow users to input custom sentiments separated by a comma.
- User can optionally specifying whether all tags must match or any tag can match.


# Demo link:
https://youtu.be/dWieHXijLGs
