### PR TITLE
Fix: Pdf preview not available when uploading

### DIFF
--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -120,7 +120,7 @@ const Upload = () => {
       }
     }
   };
-  
+
   const handleRerecord = () => {
     setSelectedVoiceNote(null);
     if (audioRef.current) {
@@ -129,8 +129,10 @@ const Upload = () => {
     }
     setIsPlaying(false);
   };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
     if (!selectedImage) {
       toast.error('Please select a file');
       return;
@@ -143,6 +145,7 @@ const Upload = () => {
 
     try {
       setIsUploading(true);
+
       // Create FormData
       const formData = new FormData();
       formData.append('username', user.firstName + " " + user.lastName);
@@ -150,6 +153,7 @@ const Upload = () => {
       formData.append('title', title);
       formData.append('description', description);
       formData.append('sentiment', sentiment === 'custom' ? customSentiment : sentiment);
+      
       // Add audio data if available
       if (selectedVoiceNote) {
         const audioReader = new FileReader();
@@ -178,6 +182,7 @@ const Upload = () => {
       });
 
       const data = await response.json();
+
       if (!response.ok) {
         throw new Error(data.error || 'Upload failed');
       }


### PR DESCRIPTION
The file uploader was enhanced to support on-demand previews for both images and PDFs, which now open in a modal overlay. Instead of an automatic preview, the UI now displays the filename with "Preview" and "Remove" buttons for better user control.
<img width="1838" height="889" alt="Screenshot from 2025-09-09 23-37-12" src="https://github.com/user-attachments/assets/cc0ff503-4277-4c83-adf3-597bc394a3c4" />
<img width="1838" height="889" alt="Screenshot from 2025-09-09 23-37-20" src="https://github.com/user-attachments/assets/d4330a00-e400-4b65-98c3-ed4fcac7af94" />

