### PR TITLE
Fix image display order

### DIFF
--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -149,8 +149,12 @@ const Gallery = () => {
           throw new Error(data.error);
         }
         
-        setImages(data.images);
-        console.log(data.images);
+        const sortedImages: Upload[] = data.images.sort((a: Upload, b: Upload) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+
+        setImages(sortedImages);
+        console.log(sortedImages);
       } catch (error) {
         console.error('Error fetching uploads:', error);
           toast.error('Failed to fetch uploads');

--- a/frontend/src/pages/admin/UserUploads.tsx
+++ b/frontend/src/pages/admin/UserUploads.tsx
@@ -55,7 +55,10 @@ const UserUploads = () => {
           throw new Error(data.error);
         }
         
-        setUploads(data.images);
+        const sortedImages: Upload[] = data.images.sort((a: Upload, b: Upload) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+        setUploads(sortedImages);
       } catch (error) {
         console.error('Error fetching uploads:', error);
         toast.error('Failed to fetch uploads');


### PR DESCRIPTION
**Description of your changes:**
Closes #229 
- Updated the user gallery to ensure images are displayed with the most recent uploads across all three views: grid view, list view, and rolling view.
<img width="1475" height="654" alt="image" src="https://github.com/user-attachments/assets/8e2baf33-d271-4fe6-899a-6ba4824d3bbd" />


- This issue was not exaclty in the admin dashbaord, instead it was in the uploads by user in user management, i have fixed that also.
<img width="1476" height="466" alt="image" src="https://github.com/user-attachments/assets/1ad7ea88-c701-43a0-9138-59e502cde713" />

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)