### PR TITLE
Fix: Pdf preview not available when uploading 

### DIFF
--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef,useEffect } from 'react';
 import { useUser, useClerk } from '@clerk/clerk-react';
 import {
   CloudArrowUpIcon,
@@ -35,6 +35,22 @@ const Upload = () => {
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      setIsPreviewing(false);
+    }
+  };
+
+  if (isPreviewing) {
+    window.addEventListener('keydown', handleKeyDown);
+  }
+
+  return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isPreviewing]);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];


### PR DESCRIPTION
**Description of your changes:**
The file uploader was enhanced to support on-demand previews for both images and PDFs, which now open in a modal overlay. Instead of an automatic preview, the UI now displays the filename with "Preview" and "Remove" buttons for better user control.
<img width="1838" height="889" alt="image" src="https://github.com/user-attachments/assets/bc792592-91b5-4041-94b0-31a5981a9545" />
<img width="1838" height="889" alt="image" src="https://github.com/user-attachments/assets/cc0bb32e-a73e-4a25-a0bb-486bb71851a8" />
Issue #230 
**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)