### PR TITLE
fix message spoofing and data leakage in chat #265

### DIFF
--- a/app.py
+++ b/app.py
@@ -306,8 +306,8 @@ def get_admin_notifications():
 def send_chat_message():
     try:
         data = request.json
-        from_id = data.get('from_id')
-        from_role = data.get('from_role')
+        from_id = request.current_user['id']
+        from_role = request.current_user['role']
         to_id = data.get('to_id')
         to_role = data.get('to_role')
         content = data.get('content')
@@ -332,7 +332,17 @@ def send_chat_message():
 @require_auth
 def get_chat_messages():
     try:
-        user_id = request.args.get('user_id')
+        current_user = request.current_user
+        
+        if current_user.get('role') == 'admin':
+            # If the requester is an admin, they can specify a user_id
+            user_id = request.args.get('user_id')
+            if not user_id:
+                return jsonify({'error': 'user_id parameter is required for admin view'}), 400
+        else:
+            # We'll be ignoring any user_id passed in the query to prevent data leakage.
+            user_id = current_user['id']
+
         with_admin = request.args.get('with_admin', 'false').lower() == 'true'
         if not user_id:
             return jsonify({'error': 'user_id is required'}), 400

--- a/frontend/src/components/ChatDrawer.tsx
+++ b/frontend/src/components/ChatDrawer.tsx
@@ -89,8 +89,6 @@ const ChatDrawer: React.FC<ChatDrawerProps> = ({ userId, userRole, targetUserId,
     setLoading(true);
     try {
       const payload = {
-        from_id: userId,
-        from_role: userRole,
         to_id: userRole === 'admin' ? adminTargetId : 'admin',
         to_role: userRole === 'admin' ? 'user' : 'admin',
         content: input.trim(),

--- a/utils/clerk_auth.py
+++ b/utils/clerk_auth.py
@@ -47,12 +47,28 @@ def require_auth(f):
                     print("No user ID found in token")
                     return jsonify({'error': 'No user ID in token'}), 401
                 
+                clerk_api_key = os.getenv('CLERK_SECRET_KEY')
+                api_url = f"https://api.clerk.com/v1/users/{user_id}"
+                headers = {'Authorization': f'Bearer {clerk_api_key}'}
+                
+                response = requests.get(api_url, headers=headers)
+
+                if not response.ok:
+                    raise Exception(f"Clerk API error: {response.text}")
+                
+                user_data = response.json()
+                
+                # Safely get the role from unsafe_metadata, defaulting to 'user'
+                role = user_data.get('unsafe_metadata', {}).get('role', 'user')
+                
+                
                 # Token is valid, user is authenticated
                 request.current_user = {
                     'id': user_id,
-                    'userid': user_id  # Your session claim
+                    'userid': user_id,  # Your session claim
+                    'role': role
                 }
-                print("Authentication successful for user:", user_id)
+                print(f"Authentication successful for user: {user_id} with role: {role}")
                 
                 return f(*args, **kwargs)
                 


### PR DESCRIPTION
## Description of your changes:
@pradeeban 
fixes #265 

### Issues
- The endpoint ```POST /api/chat/send``` accepts from_id and from_role in the request body. This allows any authenticated user to send messages that appear to be from another user.

- The endpoint ``` GET /api/chat/messages ``` allows fetching chat history based on a user_id query parameter without verifying whether the requester is the same user or an admin. This exposes private chat history to any authenticated user.

### Fixes
- Removed from_id and from_role from the request body. from_id is now taken from the token and from_role is taken from the role passed during authentication. Since frontend already uses unsafe metadata for admin checks, i have used the same data for admin checks in backend.

- Added authorization checks to ensure that only the owner of the chat or an admin can access the chat messages. Requests from users with others user_id are ignored.

**Checklist:**
- [X] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)