### PR TITLE
fix: block restricted image uploads on AI detection #326

### DIFF
--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -106,8 +106,9 @@ const aiBlock = (error: unknown) => {
       toast.success('Fields autofilled by AI ✨', { id: analysisToast });
     } catch (error) {
       console.error('Analysis error:', error);
-      toast.error(error instanceof Error ? error.message : 'Analysis failed.', { id: analysisToast });
-      aiBlock(error);
+      if (!aiBlock(error)) {
+        toast.error(error instanceof Error ? error.message : 'Analysis failed.', { id: analysisToast });
+      }
     } finally {
       setIsAnalyzing(false);
     }


### PR DESCRIPTION
fixes : #326 

This PR fixes the issue where NSFW / restricted images were still being uploaded even after AI detected blocked content. , this caused unsafe content to enter the platform.

This update ensures that when the AI indicates a blocked / restricted response, the media is immediately removed and prevented from being uploaded.

What’s Fixed

-  Prevents AI-blocked / restricted images from being uploaded
-  Automatically removes the selected image from the UI when blocked

@pradeeban 