### PR TITLE
fix: Initialize beehive_user_collection to prevent NameError

### DIFF
--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -8,6 +8,7 @@ import os
 
 beehive_image_collection = databaseConfig.get_beehive_image_collection()
 beehive_notification_collection = databaseConfig.get_beehive_notification_collection()
+beehive_user_collection = databaseConfig.get_beehive_user_collection()
 
 # Get user by username from MongoDB
 def get_user_by_username(username: str):


### PR DESCRIPTION
## What:
This pull request fixes an issue where `beehive_user_collection` was used but never initialized, causing `NameError` at runtime.

## Why:
The undefined variable causes runtime crashes in functions that depend on it. This fix ensures the collection is properly initialized before use.

## How:
Added initialization of `beehive_user_collection` using `databaseConfig.get_beehive_user_collection()`, following the same pattern as other collection initializations in the file.

## Affected Functions:
- `get_user_by_username()`
- `getallusers()`
- `get_currentuser_from_session()`
- `get_all_users()`