### PR TITLE
fix: Initialize beehive_user_collection to prevent NameError (#331)

### DIFF
--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -8,6 +8,7 @@ import os
 
 beehive_image_collection = databaseConfig.get_beehive_image_collection()
 beehive_notification_collection = databaseConfig.get_beehive_notification_collection()
+beehive_user_collection = databaseConfig.get_beehive_user_collection()
 
 # Get user by username from MongoDB
 def get_user_by_username(username: str):


### PR DESCRIPTION
Closes #331

Overview
This PR resolves a critical NameError that prevented the application from initializing or accessing user-related data due to an undefined variable.

Variable Definition/Import
Problem: The variable beehive_user_collection was referenced within [Insert File Path/Function Here, e.g., backend/src/utils.py] without being properly defined or imported into the local scope. This caused a fatal NameError during execution.

Solution Implemented: The definition/import of beehive_user_collection has been added by [clearly state the technical fix, e.g., importing it from the shared 'config' module or defining it as a global variable linked to the database client].

Impact:

Fixes the script crash caused by NameError.

Ensures stable access to the user collection for all subsequent database operations.