### PR TITLE
Fix: include voice note in upload FormData

### DIFF
--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -283,7 +283,6 @@ const MAX_SIZE:Record<string,number>={
       
       // Add audio data if available
       if (selectedVoiceNote) {
-        const formData = new FormData();
         formData.append('audio', selectedVoiceNote);
       }
       // Make the upload request


### PR DESCRIPTION
## Description

- This PR fixes an issue where the optional voice note was not included in the media upload request.
- Although recording and playback worked correctly on the client side, the audio file was never sent to the backend due to `FormData` being redeclared inside a conditional block.

## Root Cause

- Inside `handleSubmit`, a new `FormData` instance was mistakenly created within the `if (selectedVoiceNote)` block.
- This shadowed the original FormData, causing the audio file to be dropped from the request payload.

## Changes Made

- Removed the redeclaration of FormData
- Appended the audio file to the existing FormData instance when a voice note is present
- Ensured all media fields (image, metadata, audio) are sent in a single request

## Before 
<img width="936" height="326" alt="Screenshot 2025-12-18 210715" src="https://github.com/user-attachments/assets/45d90f31-c7ea-4e94-9b5d-ccba33f9e291" />

## After
<img width="927" height="315" alt="image" src="https://github.com/user-attachments/assets/306494a9-1b61-4917-948a-c0a215408c54" />

## Related Issue
- Fixes #370 

**Checklist:**
- [ ] I have [signed off my commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)

---

@pradeeban @mdxabu Please review and let me know if any further changes are needed.