### PR TITLE
feat: add recording timer indicator for voice notes

### DIFF
--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -42,7 +42,6 @@ const Upload = () => {
   const [isUploading, setIsUploading] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
   const [recordingTime, setRecordingTime] = useState(0);
-  const recordingIntervalRef = useRef<number | null>(null);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isAnalyzing, setIsAnalyzing] = useState(false); 
   const [isDragActive, setIsDragActive] = useState(false); 
@@ -51,13 +50,15 @@ const Upload = () => {
   const audioChunksRef = useRef<Blob[]>([]);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
-  useEffect(() => {
-    return () => {
-      if (recordingIntervalRef.current) {
-        clearInterval(recordingIntervalRef.current);
-      }
-    }
-  }, []);
+    useEffect(() => {
+    if (!isRecording) return;
+
+    const interval = window.setInterval(() => {
+      setRecordingTime((prev) => prev + 1);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isRecording]);
 
   // Block restricted contents
 const aiBlock = (error: unknown) => {
@@ -228,9 +229,7 @@ const MAX_SIZE:Record<string,number>={
       mediaRecorder.start();
       setIsRecording(true);
       setRecordingTime(0);
-      recordingIntervalRef.current = window.setInterval(() => {
-        setRecordingTime((prev) => prev + 1);
-      }, 1000);
+      
     } catch (error) {
       console.error('Error accessing microphone:', error);
       toast.error('Error accessing microphone');
@@ -241,10 +240,6 @@ const MAX_SIZE:Record<string,number>={
     if (mediaRecorderRef.current && isRecording) {
       mediaRecorderRef.current.stop();
       setIsRecording(false);
-      if (recordingIntervalRef.current) {
-        clearInterval(recordingIntervalRef.current);
-        recordingIntervalRef.current = null;
-      }
     }
   };
 


### PR DESCRIPTION
**Description**

This PR adds a live timer indicator while recording voice notes in the Upload page, giving users clear feedback on recording duration.

**Changes made**

- Introduced a recording timer using useEffect
- Timer starts when recording begins and stops/reset on recording end
- UI updated to display elapsed recording time

**Demo**

https://github.com/user-attachments/assets/4b66c8ad-dfb9-4ced-9dda-ea9bbbc5f956

**Related issue**

Fixes #343

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)