### PR TITLE
Fix image overflow and inconsistent layout in gallery

### DIFF
--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -814,7 +814,7 @@ const Gallery = () => {
               >
                 <motion.div
                   className={`relative cursor-pointer group ${
-                    viewMode === 'list' ? 'w-32 h-32 flex-shrink-0' : 'w-full h-52'
+                    viewMode === 'list' ? 'w-32 h-32 flex-shrink-0' : 'w-full aspect-[4/3]'
                   }`}
                   onClick={() => handleFileClick(image.filename)}
                   whileHover={{ scale: 1.05 }}


### PR DESCRIPTION
## Description

- This PR fixes a UI issue in the Gallery page where images with varying aspect ratios—especially portrait images—were overflowing their containers. This caused inconsistent card heights and disrupted the grid layout, negatively impacting visual consistency and user experience.


## Changes Made

- Added a fixed height to gallery image containers in grid view to prevent layout shifts
- Ensured consistent card dimensions across all gallery items
- Prevented image overflow caused by varying aspect ratios
- Improved overall grid alignment and UI consistency


## Screenshots

## Before 
<img width="1707" height="867" alt="Screenshot 2025-12-21 171744" src="https://github.com/user-attachments/assets/6786a322-b29d-46d6-997c-7c7f837dd868" />

## After
<img width="1901" height="857" alt="image" src="https://github.com/user-attachments/assets/c9313e5f-45bf-4c44-9ad2-3be4a3e5cf6c" />


Related Issue
- Fixes #381 

---
@pradeeban @mdxabu Please review and let me know if any further changes are needed.