### PR TITLE
fix: Restrict admin notification routes to admin users

### DIFF
--- a/app.py
+++ b/app.py
@@ -622,7 +622,7 @@ def user_images_show():
 
 
 @app.route("/api/admin/notifications", methods=["GET"])
-@require_auth
+@require_admin_role
 def get_admin_notifications():
     try:
         notification_collection = get_beehive_notification_collection()
@@ -660,7 +660,7 @@ def get_admin_notifications():
 
 
 @app.route("/api/admin/notifications/mark_seen", methods=["POST"])
-@require_auth
+@require_admin_role
 def mark_selected_notifications_seen():
     try:
         notification_collection = get_beehive_notification_collection()


### PR DESCRIPTION
### Summary
Replaced `@require_auth` with `@require_admin_role` on admin notification routes to prevent non-admin access.

### Changes
- `app.py:625` — `get_admin_notifications` now restricted to admin users
- `app.py:663` — `mark_selected_notifications_seen` now restricted to admin users

### Result
The security issue is resolved. Only users with admin roles can access admin notification endpoints.

### Fixes 
- #394 

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)