### PR TITLE
Remove LinkedIn and GitHub links in the Team section

### DIFF
--- a/frontend/src/pages/AboutUs.tsx
+++ b/frontend/src/pages/AboutUs.tsx
@@ -6,11 +6,6 @@ interface TeamMember {
   role: string;
   affiliation: string;
   image: string;
-  socials?: {
-    github?: string;
-    linkedin?: string;
-    twitter?: string;
-  };
   bio?: string;
 }
 
@@ -21,10 +16,6 @@ const AboutUs = () => {
       role: "Org Maintainer - Project Lead",
       affiliation: "University of Alaska Anchorage",
       image: "/team/member1.jpeg",
-      socials: {
-        github: "https://github.com/pradeeban",
-        linkedin: "#",
-      },
       bio: "Leading the development of Beehive and mentoring the team."
     },
     {
@@ -32,9 +23,6 @@ const AboutUs = () => {
       role: "Org Maintainer - Project Lead",
       affiliation: "University of Alaska Anchorage",
       image: "/team/member6.jpeg",
-      socials: {
-        linkedin: "#",
-      },
       bio: "Guiding the project's vision and research direction."
     },
     {
@@ -42,10 +30,6 @@ const AboutUs = () => {
       role: "Developer",
       affiliation: "Google Summer of Code - 25",
       image: "/team/member2.jpeg",
-      socials: {
-        github: "https://github.com/ishaanxgupta",
-        linkedin: "https://www.linkedin.com/in/ishaan-gupta-972a23251/",
-      },
       bio: "Contributing to the frontend development and user experience."
     },
     {
@@ -53,10 +37,6 @@ const AboutUs = () => {
       role: "Developer",
       affiliation: "Google Summer of Code - 25",
       image: "/team/member3.jpeg",
-      socials: {
-        github: "#",
-        linkedin: "#",
-      },
       bio: "Working on backend infrastructure and data management."
     },
     {
@@ -64,10 +44,6 @@ const AboutUs = () => {
       role: "Developer",
       affiliation: "Alaskan Season of Code - 24",
       image: "/team/member4.png",
-      socials: {
-        github: "#",
-        linkedin: "#",
-      },
       bio: "Focusing on system architecture and integration."
     },
  
@@ -216,33 +192,6 @@ const AboutUs = () => {
                         alt={member.name}
                         className="w-full h-full object-cover transform group-hover:scale-110 transition-transform duration-300"
                       />
-                    </div>
-                    {/* Social Links */}
-                    <div className="absolute -bottom-2 left-1/2 transform -translate-x-1/2 flex gap-2 opacity-0 group-hover:opacity-100 group-hover:translate-y-0 translate-y-4 transition-all duration-300">
-                      {member.socials?.github && (
-                        <a
-                          href={member.socials.github}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="bg-black text-white p-2 rounded-full hover:bg-gray-800 transition-colors"
-                        >
-                          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                            <path fillRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.137 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" clipRule="evenodd" />
-                          </svg>
-                        </a>
-                      )}
-                      {member.socials?.linkedin && (
-                        <a
-                          href={member.socials.linkedin}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="bg-blue-600 text-white p-2 rounded-full hover:bg-blue-700 transition-colors"
-                        >
-                          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
-                          </svg>
-                        </a>
-                      )}
                     </div>
                   </div>
 


### PR DESCRIPTION
**Description of your changes:**
This PR removes the LinkedIn and GitHub links/icons from the Team section of the website, as discussed in https://github.com/KathiraveluLab/Beehive/issues/329.
* The decision was made to avoid promoting individual social media profiles within the framework, focusing on the open-source project as a whole.

### Changes:
Removed LinkedIn and GitHub icons/links from the Team section.

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)