### PR TITLE
Fix inverted logic in check_admin_available

### DIFF
--- a/database/admindatahandler.py
+++ b/database/admindatahandler.py
@@ -24,7 +24,7 @@ def check_admin_available(google_id: str):
     }
 
     count = beehive_admin_collection.count_documents(query)
-    return count == 0
+    return count > 0
 
 def is_admin():
     # Check admin based on google_id (for Google sign-in)


### PR DESCRIPTION
## Summary

This PR fixes an inverted return condition in the `check_admin_available` function.

The function name and expected behavior imply that it should return `True` when an admin already exists for a given `google_id`. However, the previous implementation returned `True` only when no matching admin existed in the database.

This change aligns the function’s behavior with its name and expected usage.

---

## Changes

- Updated the return condition in `check_admin_available`
- Now returns `True` when an admin exists (`count > 0`)

---

## Before

```python
return count == 0
```
True → admin does not exist
False → admin exists


### After
```python
return count > 0
```
True → admin exists
False → admin does not exist



## Related Issue
- Fixes #412 

**Checklist:**
- [ ] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)


---

@pradeeban @mdxabu Please review and let me know if any further changes are needed.