### PR TITLE
Fix: Migrate Analytics page to useClerk hook for authentication

### DIFF
--- a/frontend/src/pages/admin/Analytics.tsx
+++ b/frontend/src/pages/admin/Analytics.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useClerk } from '@clerk/clerk-react';
 import {
   CalendarIcon,
   ChartBarIcon,
@@ -131,12 +132,13 @@ const Analytics = () => {
   const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const clerk = useClerk();
 
-  const fetchDashboardData = async () => {
+  const fetchDashboardData = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
-      const token = await window.Clerk.session?.getToken();
+      const token = await clerk.session?.getToken();
       const response = await fetch(apiUrl('/api/admin/analytics'), {
         method: "GET",
         headers: {
@@ -154,11 +156,11 @@ const Analytics = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [clerk.session]);
 
   useEffect(() => {
     fetchDashboardData();
-  }, []);
+  }, [fetchDashboardData]);
 
   if (loading) return (
     <div className="flex justify-center items-center h-32">


### PR DESCRIPTION
### Summary
Refactors the Analytics admin page to use the official `useClerk` hook instead of accessing the global `window.Clerk` object directly.

### Changes
- Added `useCallback` import from React
- Added `useClerk` hook import from `@clerk/clerk-react`
- Replaced `window.Clerk.session?.getToken()` with `clerk.session?.getToken()`
- Wrapped `fetchDashboardData` in `useCallback` with proper dependencies
- Fixed `useEffect` exhaustive-deps warning by adding `fetchDashboardData` to dependency array

### Why
- **Type Safety**: Hook provides proper TypeScript types
- **React Best Practices**: Follows idiomatic React patterns
- **Reactivity**: Component now properly responds to session changes
- **Linting**: Resolves ESLint `react-hooks/exhaustive-deps` warning

### Related Isuues

- Fixes #428 


**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)