### PR TITLE
fix(gallery): handle empty uploads as valid state

### DIFF
--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -127,7 +127,6 @@ const Gallery = () => {
       try {
         setLoading(true);
         
-        // Get the authentication token from Clerk
         const token = await window.Clerk.session?.getToken();
         
         const response = await fetch(`http://127.0.0.1:5000/api/user/user_uploads/${user.id}`, {
@@ -141,23 +140,25 @@ const Gallery = () => {
         });
         
         if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+          toast.error('Failed to fetch uploads');
+          return;
         }
         
         const data = await response.json();
+        
         if (data.error) {
-          throw new Error(data.error);
+          toast.error('Failed to fetch uploads');
+          return;
         }
         
-        const sortedImages: Upload[] = data.images.sort((a: Upload, b: Upload) =>
+        const sortedImages: Upload[] = (data.images || []).sort((a: Upload, b: Upload) =>
           new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
         );
 
         setImages(sortedImages);
-        console.log(sortedImages);
       } catch (error) {
         console.error('Error fetching uploads:', error);
-          toast.error('Failed to fetch uploads');
+        toast.error('Failed to fetch uploads');
       } finally {
         setLoading(false);
       }
@@ -602,6 +603,14 @@ const Gallery = () => {
         {loading ? (
           <div className="flex justify-center items-center h-64">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-yellow-400"></div>
+          </div>
+        ) : images.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-64 text-center">
+            <svg className="w-16 h-16 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">No uploads yet</h3>
+            <p className="text-gray-500 dark:text-gray-400">Start by uploading your first image</p>
           </div>
         ) : viewMode === 'rolling' ? (
           renderRollingView()


### PR DESCRIPTION
The Gallery page was showing error toasts for users with no uploads.

This change treats empty uploads as a normal state and shows a simple empty message instead.

Fixes #444

<img width="958" height="509" alt="image" src="https://github.com/user-attachments/assets/98e58fb1-d671-4374-8309-744f504e08e3" />
