### PR TITLE
fix(gallery): handle empty uploads as valid state instead of error

### DIFF
--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -180,15 +180,21 @@ const Gallery = () => {
       });
       
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        if (page === 1) {
+          toast.error('Failed to fetch uploads');
+        }
+        return;
       }
       
       const data = await response.json();
       if (data.error) {
-        throw new Error(data.error);
+        if (page === 1) {
+          toast.error('Failed to fetch uploads');
+        }
+        return;
       }
       
-      const sortedImages: Upload[] = data.images.sort((a: Upload, b: Upload) =>
+      const sortedImages: Upload[] = (data.images || []).sort((a: Upload, b: Upload) =>
         new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
       );
 


### PR DESCRIPTION
The Gallery page was showing error toasts for users with no uploads.

This change treats empty uploads as a normal state and shows a simple empty message instead.

Fixes #444 


<img width="1915" height="1018" alt="image" src="https://github.com/user-attachments/assets/6a59722d-146b-4cc0-8e38-a1d88ce255fa" />
