### PR TITLE
Fix :  Persist upload draft and harden validation

### DIFF
--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -70,10 +70,10 @@ const Upload = () => {
         sentiment: SentimentType;
         customSentiment: string;
       }>;
-      if (draft.title) setTitle(draft.title);
-      if (draft.description) setDescription(draft.description);
-      if (draft.sentiment) setSentiment(draft.sentiment);
-      if (draft.customSentiment) setCustomSentiment(draft.customSentiment);
+      if (draft.title !== undefined) setTitle(draft.title);
+      if (draft.description !== undefined) setDescription(draft.description);
+      if (draft.sentiment !== undefined) setSentiment(draft.sentiment);
+      if (draft.customSentiment !== undefined) setCustomSentiment(draft.customSentiment);
     } catch (err) {
       console.warn('Failed to load upload draft', err);
     } finally {


### PR DESCRIPTION
### Summary 

- Persist upload form drafts per user using localStorage, allowing recovery after a page refresh; drafts are cleared automatically upon successful upload.
- Prevent submission while analysis is in progress or when required fields are incomplete (image, title, description, and custom sentiment when applicable).
- Improve the upload dropzone by explicitly displaying supported file types and maximum file size constraints.


**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)