### PR TITLE
Fix: CORS Blocking Image Delete/Edit

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,6 +86,7 @@ CORS(
         },
         r"/audio/*": {
             "origins": ["http://localhost:5173"],
+            "methods": ["GET", "OPTIONS"],
             "allow_headers": ["Content-Type", "Authorization"],
             "supports_credentials": True,
         }


### PR DESCRIPTION
### Description

### Root Cause
CORS was configured **only for `/api/*` routes**, but several active endpoints were outside that scope:
- `/delete/<image_id>`
- `/edit/<image_id>`
- `/audio/<filename>`

These routes were blocked by the browser during preflight checks.

### Fix
Extended Flask CORS configuration to explicitly allow:
- `/delete/*`
- `/edit/*`
- `/audio/*`

with proper methods, headers, and credentials support.

### Related issue
- closes #479 


**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)