### PR TITLE
fix(gallery): resolve audio memory leaks and playback race issues

### DIFF
--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -402,12 +402,16 @@ const Gallery = () => {
       const blob = await response.blob();
 
       if (controller.signal.aborted) {
-        URL.revokeObjectURL(URL.createObjectURL(blob));
         return;
       }
 
       const objectUrl = URL.createObjectURL(blob);
-      setCurrentAudioUrl(objectUrl);
+      setCurrentAudioUrl((prevUrl) => {
+        if (prevUrl) {
+          URL.revokeObjectURL(prevUrl);
+        }
+        return objectUrl;
+      });
       setAudioLoading(false);
 
       if (audioRef.current) {


### PR DESCRIPTION
Issue:

The gallery audio playback had a few problems that showed up after using it for a while.
Blob URLs were not being released properly, which caused memory leaks. Switching between audio clips quickly could trigger multiple requests at the same time, leading to race conditions, broken playback, and confusing UI behavior. There was also no clear loading or failure feedback for users.

Solution:

This change cleans up audio handling end-to-end. Blob URLs are now properly revoked whenever audio changes or the component unmounts. In-flight audio requests are cancelled using `AbortController` to avoid race conditions, and a loading state prevents multiple audio loads at once. The UI now shows clear loading feedback and handles audio errors more gracefully. Overall, audio playback is more stable, predictable, and leak-free.

**Checklist:**
- [x] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)