### PR TITLE
Update contribution guidelines to remove pre-commit step

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,11 +2,6 @@
 
 Thank you for considering contributing to our project! To ensure a smooth collaboration, please follow these guidelines when submitting contributions.
 
-## Before commiting it is recommended to run:
-```bash
-pre-commit run --all-files
-```
-This will ensure that black, flake and isort is run.
 
 ## 1. Sign off your commits
 


### PR DESCRIPTION
Removed pre-commit instructions from the contribution guidelines.

**Description of your changes:**


**Checklist:**
- [ ] You have [signed off your commits](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#1-sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)