### PR TITLE
Enforce OTP verification during user signup

### DIFF
--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -69,5 +69,19 @@ def initialize_text_index():
             logger.info("Text index created on image collection")
         else:
             logger.debug("Text index already exists on image collection")
+        # Ensure an index exists for OTP verification queries to keep lookups fast
+        try:
+            otp_collection = beehive.email_otps
+            otp_indexes = otp_collection.index_information()
+            if 'email_verified_idx' not in otp_indexes:
+                otp_collection.create_index(
+                    [("email", 1), ("verified", 1), ("verified_at", -1)],
+                    name='email_verified_idx',
+                )
+                logger.info("Created index on email_otps (email, verified, verified_at)")
+            else:
+                logger.debug("email_verified_idx already exists on email_otps")
+        except Exception as ie:
+            logger.error(f"Error creating email_otps index: {ie}")
     except Exception as e:
         logger.error(f"Error creating text index: {str(e)}")

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -15,6 +15,41 @@ from database.databaseConfig import beehive
 
 auth_bp = Blueprint("auth", __name__)
 
+OTP_VERIFICATION_WINDOW_SECONDS = 600  # 10 minutes
+
+
+def _validate_otp_verification(email: str):
+    """Check that a valid, unexpired OTP verification session exists for email.
+
+    Returns a Flask response tuple (jsonify(...), status_code) if validation
+    fails, or None if the email is properly verified.
+    """
+    otp_record = db.email_otps.find_one({"email": email, "verified": True})
+    if not otp_record:
+        return (
+            jsonify({"error": "Email not verified. Please complete OTP verification first."}),
+            403,
+        )
+
+    verified_at = otp_record.get("verified_at")
+    if not verified_at:
+        return (
+            jsonify({"error": "Invalid verification session. Please restart signup."}),
+            403,
+        )
+
+    if verified_at.tzinfo is None:
+        verified_at = verified_at.replace(tzinfo=timezone.utc)
+
+    if (datetime.now(timezone.utc) - verified_at).total_seconds() > OTP_VERIFICATION_WINDOW_SECONDS:
+        db.email_otps.delete_many({"email": email})
+        return (
+            jsonify({"error": "Verification session expired. Please restart signup."}),
+            403,
+        )
+
+    return None
+
 # Create EMAIL OTP
 def create_email_otp(email: str) -> str:
     otp = str(secrets.randbelow(900000) + 100000)
@@ -139,36 +174,10 @@ def complete_signup():
     # Validate password length
     if len(password) < 8:
         return jsonify({"error": "Password must be at least 8 characters"}), 400
-    # Verify that OTP was actually completed for this email
-    otp_record = db.email_otps.find_one({"email": email, "verified": True})
-    if not otp_record:
-        return (
-            jsonify(
-                {"error": "Email not verified. Please complete OTP verification first."}
-            ),
-            403,
-        )
-
-    # Check if OTP verification session has expired (10 min window)
-    verified_at = otp_record.get("verified_at")
-    if not verified_at:
-        return (
-            jsonify({"error": "Invalid verification session. Please restart signup."}),
-            403,
-        )
-
-    if verified_at.tzinfo is None:
-        verified_at = verified_at.replace(tzinfo=timezone.utc)
-
-    # Check if OTP verification session has expired (10 min window)
-    if (datetime.now(timezone.utc) - verified_at).total_seconds() > (10 * 60):
-        db.email_otps.delete_many({"email": email})
-        return (
-            jsonify(
-                {"error": "Verification session expired. Please restart signup."}
-            ),
-            403,
-        )
+    # Verify OTP session before creating the account
+    otp_error = _validate_otp_verification(email)
+    if otp_error:
+        return otp_error
 
     # Prevent duplicate email
     if db.users.find_one({"email": email}):
@@ -268,29 +277,10 @@ def set_password():
         if existing_user:
             return jsonify({"error": "User already exists"}), 400
 
-        # Verify that OTP was actually completed for this email
-        otp_record = db.email_otps.find_one({"email": email, "verified": True})
-        if not otp_record:
-            return (
-                jsonify(
-                    {"error": "Email not verified. Please complete OTP verification first."}
-                ),
-                403,
-            )
-
-        # Check if OTP verification session has expired (10 min window)
-        verified_at = otp_record.get("verified_at")
-        if verified_at:
-            if verified_at.tzinfo is None:
-                verified_at = verified_at.replace(tzinfo=timezone.utc)
-            if (datetime.now(timezone.utc) - verified_at).total_seconds() > 600:
-                db.email_otps.delete_many({"email": email})
-                return (
-                    jsonify(
-                        {"error": "Verification session expired. Please restart signup."}
-                    ),
-                    403,
-                )
+        # Verify OTP session before creating the account
+        otp_error = _validate_otp_verification(email)
+        if otp_error:
+            return otp_error
 
         role = "admin" if is_admin_email(email) else "user"
 

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -261,6 +261,30 @@ def set_password():
         if existing_user:
             return jsonify({"error": "User already exists"}), 400
 
+        # Verify that OTP was actually completed for this email
+        otp_record = db.email_otps.find_one({"email": email, "verified": True})
+        if not otp_record:
+            return (
+                jsonify(
+                    {"error": "Email not verified. Please complete OTP verification first."}
+                ),
+                403,
+            )
+
+        # Check if OTP verification session has expired (10 min window)
+        verified_at = otp_record.get("verified_at")
+        if verified_at:
+            if verified_at.tzinfo is None:
+                verified_at = verified_at.replace(tzinfo=timezone.utc)
+            if (datetime.now(timezone.utc) - verified_at).total_seconds() > 600:
+                db.email_otps.delete_many({"email": email})
+                return (
+                    jsonify(
+                        {"error": "Verification session expired. Please restart signup."}
+                    ),
+                    403,
+                )
+
         role = "admin" if is_admin_email(email) else "user"
 
         user_id = db.users.insert_one({
@@ -270,6 +294,9 @@ def set_password():
             "role": role,
             "created_at": datetime.now(timezone.utc)
         }).inserted_id
+
+        # Cleanup OTPs
+        db.email_otps.delete_many({"email": email})
 
     elif purpose == "reset":
         if not existing_user:

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -151,17 +151,24 @@ def complete_signup():
 
     # Check if OTP verification session has expired (10 min window)
     verified_at = otp_record.get("verified_at")
-    if verified_at:
-        if verified_at.tzinfo is None:
-            verified_at = verified_at.replace(tzinfo=timezone.utc)
-        if (datetime.now(timezone.utc) - verified_at).total_seconds() > 600:
-            db.email_otps.delete_many({"email": email})
-            return (
-                jsonify(
-                    {"error": "Verification session expired. Please restart signup."}
-                ),
-                403,
-            )
+    if not verified_at:
+        return (
+            jsonify({"error": "Invalid verification session. Please restart signup."}),
+            403,
+        )
+
+    if verified_at.tzinfo is None:
+        verified_at = verified_at.replace(tzinfo=timezone.utc)
+
+    # Check if OTP verification session has expired (10 min window)
+    if (datetime.now(timezone.utc) - verified_at).total_seconds() > (10 * 60):
+        db.email_otps.delete_many({"email": email})
+        return (
+            jsonify(
+                {"error": "Verification session expired. Please restart signup."}
+            ),
+            403,
+        )
 
     # Prevent duplicate email
     if db.users.find_one({"email": email}):

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -107,7 +107,12 @@ def verify_otp():
         if expires_at < datetime.now(timezone.utc):
             return jsonify({"error": "OTP expired"}), 400
 
-        db.email_otps.delete_many({"email": email})
+        # Mark email as verified instead of deleting
+        # This flag is checked by complete-signup to prevent OTP bypass
+        db.email_otps.update_one(
+            {"email": email},
+            {"$set": {"verified": True, "verified_at": datetime.now(timezone.utc)}},
+        )
 
         return jsonify({"message": "OTP verified"}), 200
 
@@ -134,6 +139,30 @@ def complete_signup():
     # Validate password length
     if len(password) < 8:
         return jsonify({"error": "Password must be at least 8 characters"}), 400
+    # Verify that OTP was actually completed for this email
+    otp_record = db.email_otps.find_one({"email": email, "verified": True})
+    if not otp_record:
+        return (
+            jsonify(
+                {"error": "Email not verified. Please complete OTP verification first."}
+            ),
+            403,
+        )
+
+    # Check if OTP verification session has expired (10 min window)
+    verified_at = otp_record.get("verified_at")
+    if verified_at:
+        if verified_at.tzinfo is None:
+            verified_at = verified_at.replace(tzinfo=timezone.utc)
+        if (datetime.now(timezone.utc) - verified_at).total_seconds() > 600:
+            db.email_otps.delete_many({"email": email})
+            return (
+                jsonify(
+                    {"error": "Verification session expired. Please restart signup."}
+                ),
+                403,
+            )
+
     # Prevent duplicate email
     if db.users.find_one({"email": email}):
         return jsonify({"error": "Email already registered"}), 400
@@ -213,7 +242,7 @@ def set_password():
     try:
         email = validate_email(data.get("email"))
         password = sanitize_string(data.get("password"))
-        purpose = sanitize_string(data.get("purpose"), field_name="purpose")
+        purpose = sanitize_string(data.get("purpose"), field_name="purpose").lower()
     except ValidationError as e:
         current_app.logger.warning("SET PASSWORD VALIDATION ERROR")
         return jsonify({"error": str(e)}), 400

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -24,7 +24,10 @@ def _validate_otp_verification(email: str):
     Returns a Flask response tuple (jsonify(...), status_code) if validation
     fails, or None if the email is properly verified.
     """
-    otp_record = db.email_otps.find_one({"email": email, "verified": True})
+    otp_record = db.email_otps.find_one(
+        {"email": email, "verified": True},
+        sort=[("verified_at", -1)],
+    )
     if not otp_record:
         return (
             jsonify({"error": "Email not verified. Please complete OTP verification first."}),
@@ -144,8 +147,9 @@ def verify_otp():
 
         # Mark email as verified instead of deleting
         # This flag is checked by complete-signup to prevent OTP bypass
+        # Use _id to target the exact validated record, not just email
         db.email_otps.update_one(
-            {"email": email},
+            {"_id": record["_id"]},
             {"$set": {"verified": True, "verified_at": datetime.now(timezone.utc)}},
         )
 
@@ -299,10 +303,18 @@ def set_password():
         if not existing_user:
             return jsonify({"error": "User not found"}), 404
 
+        # Verify OTP session before allowing password reset
+        otp_error = _validate_otp_verification(email)
+        if otp_error:
+            return otp_error
+
         db.users.update_one(
             {"email": email},
             {"$set": {"password": hashed}}
         )
+
+        # Cleanup OTPs after successful reset
+        db.email_otps.delete_many({"email": email})
 
         user_id = existing_user["_id"]
         role = existing_user.get("role", "user")

--- a/tests/test_auth_otp_security.py
+++ b/tests/test_auth_otp_security.py
@@ -1,0 +1,228 @@
+from datetime import datetime, timedelta, timezone
+
+import bcrypt
+import routes.auth as auth_module
+
+
+class _InsertResult:
+    def __init__(self, inserted_id):
+        self.inserted_id = inserted_id
+
+
+class _Collection:
+    def __init__(self):
+        self._docs = []
+        self._next_id = 1
+
+    def _matches(self, doc, query):
+        for key, value in query.items():
+            if doc.get(key) != value:
+                return False
+        return True
+
+    def find_one(self, query, sort=None):
+        matches = [doc for doc in self._docs if self._matches(doc, query)]
+        if not matches:
+            return None
+
+        if sort:
+            field, direction = sort[0]
+            reverse = direction == -1
+            matches.sort(key=lambda d: d.get(field) or datetime.min.replace(tzinfo=timezone.utc), reverse=reverse)
+
+        return matches[0]
+
+    def insert_one(self, doc):
+        new_doc = dict(doc)
+        if "_id" not in new_doc:
+            new_doc["_id"] = self._next_id
+            self._next_id += 1
+        self._docs.append(new_doc)
+        return _InsertResult(new_doc["_id"])
+
+    def delete_many(self, query):
+        self._docs = [doc for doc in self._docs if not self._matches(doc, query)]
+
+    def update_one(self, query, update):
+        target = self.find_one(query)
+        if not target:
+            return
+        set_values = update.get("$set", {})
+        for key, value in set_values.items():
+            target[key] = value
+
+
+class _FakeDB:
+    def __init__(self):
+        self.users = _Collection()
+        self.email_otps = _Collection()
+
+
+
+def _seed_existing_user(fake_db, email, username="existing_user", password="OldPass@123"):
+    hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt())
+    fake_db.users.insert_one(
+        {
+            "email": email,
+            "username": username,
+            "password": hashed,
+            "role": "user",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+
+def _seed_otp_record(fake_db, email, otp="123456", expires_delta_minutes=5):
+    fake_db.email_otps.insert_one(
+        {
+            "email": email,
+            "otp": otp,
+            "expires_at": datetime.now(timezone.utc) + timedelta(minutes=expires_delta_minutes),
+        }
+    )
+
+
+
+def _seed_verified_otp_record(fake_db, email, verified_minutes_ago=1):
+    fake_db.email_otps.insert_one(
+        {
+            "email": email,
+            "otp": "123456",
+            "expires_at": datetime.now(timezone.utc) + timedelta(minutes=5),
+            "verified": True,
+            "verified_at": datetime.now(timezone.utc) - timedelta(minutes=verified_minutes_ago),
+        }
+    )
+
+
+
+def test_complete_signup_requires_verified_otp(client, monkeypatch):
+    fake_db = _FakeDB()
+    monkeypatch.setattr(auth_module, "db", fake_db)
+
+    response = client.post(
+        "/api/auth/complete-signup",
+        json={
+            "email": "novalidation@example.com",
+            "username": "otp_user_1",
+            "password": "StrongPass@123",
+        },
+    )
+
+    assert response.status_code == 403
+    assert "Email not verified" in response.get_json()["error"]
+
+
+
+def test_complete_signup_rejects_expired_verified_session(client, monkeypatch):
+    fake_db = _FakeDB()
+    monkeypatch.setattr(auth_module, "db", fake_db)
+    _seed_verified_otp_record(fake_db, "expired@example.com", verified_minutes_ago=11)
+
+    response = client.post(
+        "/api/auth/complete-signup",
+        json={
+            "email": "expired@example.com",
+            "username": "otp_user_2",
+            "password": "StrongPass@123",
+        },
+    )
+
+    assert response.status_code == 403
+    assert "expired" in response.get_json()["error"].lower()
+
+
+
+def test_verify_then_complete_signup_succeeds_within_window(client, monkeypatch):
+    fake_db = _FakeDB()
+    monkeypatch.setattr(auth_module, "db", fake_db)
+    _seed_otp_record(fake_db, "fresh@example.com", otp="654321")
+
+    verify_response = client.post(
+        "/api/auth/verify-otp",
+        json={"email": "fresh@example.com", "otp": "654321"},
+    )
+    assert verify_response.status_code == 200
+
+    signup_response = client.post(
+        "/api/auth/complete-signup",
+        json={
+            "email": "fresh@example.com",
+            "username": "otp_user_3",
+            "password": "StrongPass@123",
+        },
+    )
+
+    assert signup_response.status_code == 201
+    body = signup_response.get_json()
+    assert "access_token" in body
+    assert body["role"] == "user"
+    assert fake_db.users.find_one({"email": "fresh@example.com"}) is not None
+
+
+
+def test_set_password_reset_requires_verified_otp(client, monkeypatch):
+    fake_db = _FakeDB()
+    monkeypatch.setattr(auth_module, "db", fake_db)
+    _seed_existing_user(fake_db, "resetuser@example.com", username="reset_user")
+
+    response = client.post(
+        "/api/auth/set-password",
+        json={
+            "email": "resetuser@example.com",
+            "password": "NewPass@123",
+            "purpose": "reset",
+        },
+    )
+
+    assert response.status_code == 403
+    assert "Email not verified" in response.get_json()["error"]
+
+
+
+def test_set_password_reset_rejects_expired_verified_session(client, monkeypatch):
+    fake_db = _FakeDB()
+    monkeypatch.setattr(auth_module, "db", fake_db)
+    _seed_existing_user(fake_db, "resetexpired@example.com", username="reset_expired")
+    _seed_verified_otp_record(fake_db, "resetexpired@example.com", verified_minutes_ago=11)
+
+    response = client.post(
+        "/api/auth/set-password",
+        json={
+            "email": "resetexpired@example.com",
+            "password": "NewPass@123",
+            "purpose": "reset",
+        },
+    )
+
+    assert response.status_code == 403
+    assert "expired" in response.get_json()["error"].lower()
+
+
+
+def test_verify_then_set_password_reset_succeeds_within_window(client, monkeypatch):
+    fake_db = _FakeDB()
+    monkeypatch.setattr(auth_module, "db", fake_db)
+    _seed_existing_user(fake_db, "resetok@example.com", username="reset_ok")
+    _seed_otp_record(fake_db, "resetok@example.com", otp="111222")
+
+    verify_response = client.post(
+        "/api/auth/verify-otp",
+        json={"email": "resetok@example.com", "otp": "111222"},
+    )
+    assert verify_response.status_code == 200
+
+    reset_response = client.post(
+        "/api/auth/set-password",
+        json={
+            "email": "resetok@example.com",
+            "password": "BrandNew@123",
+            "purpose": "reset",
+        },
+    )
+
+    assert reset_response.status_code == 200
+    body = reset_response.get_json()
+    assert "access_token" in body
+    assert body["role"] == "user"


### PR DESCRIPTION
### What:
This pull request fixes a critical security vulnerability where the OTP verification step could be bypassed during the signup process.

### Why:
Previously, the `complete-signup` endpoint did not verify if the email had actually been verified via OTP. This allowed anyone to register an account with any email address by simply skipping the `verify-otp` API call. This fixes a high-severity security regression and closes #512.

### How:
- Modify [verify_otp](cci:1://file:///c:/Users/ANISH/OneDrive/Desktop/osC/Beehive/routes/auth.py:82:0-120:54) in [routes/auth.py](cci:7://file:///c:/Users/ANISH/OneDrive/Desktop/osC/Beehive/routes/auth.py:0:0-0:0) to mark OTP records as `verified: True` with a timestamp, instead of immediately deleting them.
- Update [complete_signup](cci:1://file:///c:/Users/ANISH/OneDrive/Desktop/osC/Beehive/routes/auth.py:123:0-197:11) in [routes/auth.py](cci:7://file:///c:/Users/ANISH/OneDrive/Desktop/osC/Beehive/routes/auth.py:0:0-0:0) to check for the existence of a valid, verified OTP record for the email before creating the user account.
- Add validation to ensure the verified OTP session is not older than 10 minutes.
- Add logic to clean up and delete the OTP record only after successful account creation.
