### PR TITLE
Fix: redirect user to login when API returns 401

### DIFF
--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -1,0 +1,1 @@
+export const SIGN_IN_PATH = '/sign-in';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,7 +12,7 @@ const originalFetch = window.fetch;
 window.fetch = async (...args) => {
   const res = await originalFetch(...args);
 
-  const url = typeof args[0] === "string" ? args[0] : args[0].url;
+  const url = args[0] instanceof Request ? args[0].url : String(args[0]);
 
   // Only handle 401 if it comes from the backend API endpoint
   const isBackendApiRequest = url.startsWith(API_BASE_URL);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -24,6 +24,8 @@ window.fetch = async (...args) => {
   ) {
     logout();
     window.location.href = '/sign-in';
+    // Prevent downstream code from processing the 401 response.
+    return new Promise(() => {});
   }
 
   return res;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,18 @@ import { createRoot } from 'react-dom/client'
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import './index.css'
 import App from './App.tsx'
+import { logout } from './utils/auth'
+
+// Global 401 interceptor - redirects to sign-in on unauthorized responses
+const originalFetch = window.fetch;
+window.fetch = async (...args) => {
+  const res = await originalFetch(...args);
+  if (res.status === 401 && window.location.pathname !== '/sign-in') {
+    logout();
+    window.location.href = '/sign-in';
+  }
+  return res;
+};
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,27 +5,48 @@ import './index.css'
 import App from './App.tsx'
 import { logout } from './utils/auth'
 import { API_BASE_URL } from './utils/api'
+import { SIGN_IN_PATH } from './constants/routes'
 
-// Global 401 interceptor - redirects to sign-in on unauthorized responses from backend API
+// Validate that URL is from our backend API (prevents URL bypass attacks)
+const isBackendRequest = (url: string): boolean => {
+  try {
+    const urlObj = new URL(url, window.location.origin);
+    const apiObj = new URL(API_BASE_URL);
+    // Strict check: same protocol, host, and port; path must start with API path
+    return (
+      urlObj.protocol === apiObj.protocol &&
+      urlObj.host === apiObj.host &&
+      urlObj.pathname.startsWith(apiObj.pathname)
+    );
+  } catch {
+    return false;
+  }
+};
+
+// Global 401 interceptor - redirects to sign-in on unauthorized responses from backend API only
 const originalFetch = window.fetch;
 
 window.fetch = async (...args) => {
   const res = await originalFetch(...args);
 
-  const url = args[0] instanceof Request ? args[0].url : String(args[0]);
+  const urlString = typeof args[0] === "string" ? args[0] : args[0]?.url;
+  const isBackendApiRequest = urlString && isBackendRequest(urlString);
 
-  // Only handle 401 if it comes from the backend API endpoint
-  const isBackendApiRequest = url.startsWith(API_BASE_URL);
-
+  // Only handle 401 from backend API (not from external requests)
   if (
     res.status === 401 &&
     isBackendApiRequest &&
-    !window.location.pathname.startsWith('/sign-in')
+    !window.location.pathname.startsWith(SIGN_IN_PATH)
   ) {
-    logout();
-    window.location.href = '/sign-in';
-    // Prevent downstream code from processing the 401 response.
-    return new Promise(() => {});
+    try {
+      logout();
+    } catch (error) {
+      console.error('Logout failed:', error);
+    }
+    // Redirect to sign-in (use setTimeout to allow pending requests to complete)
+    setTimeout(() => {
+      window.location.href = SIGN_IN_PATH;
+    }, 0);
   }
 
   return res;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,15 +4,28 @@ import { GoogleOAuthProvider } from "@react-oauth/google";
 import './index.css'
 import App from './App.tsx'
 import { logout } from './utils/auth'
+import { API_BASE_URL } from './utils/api'
 
-// Global 401 interceptor - redirects to sign-in on unauthorized responses
+// Global 401 interceptor - redirects to sign-in on unauthorized responses from backend API
 const originalFetch = window.fetch;
+
 window.fetch = async (...args) => {
   const res = await originalFetch(...args);
-  if (res.status === 401 && window.location.pathname !== '/sign-in') {
+
+  const url = typeof args[0] === "string" ? args[0] : args[0].url;
+
+  // Only handle 401 if it comes from the backend API endpoint
+  const isBackendApiRequest = url.startsWith(API_BASE_URL);
+
+  if (
+    res.status === 401 &&
+    isBackendApiRequest &&
+    !window.location.pathname.startsWith('/sign-in')
+  ) {
     logout();
     window.location.href = '/sign-in';
   }
+
   return res;
 };
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:5000';
+export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:5000';
 
 export const apiUrl = (path: string): string => {
   const cleanPath = path.startsWith('/') ? path : `/${path}`;


### PR DESCRIPTION
## Related Issue
Fixes #545

## Description
This PR adds a global fetch interceptor to handle `401 Unauthorized`
responses and redirect users to the login page.

## Changes
- Added a global fetch interceptor
- Detects `401` responses
- Redirects the user to `/login`

## Why this change
Currently when the backend returns a `401`, the application
does not redirect the user to the login page, leaving the UI
in an unauthenticated state.

This change ensures consistent authentication handling.

## Testing
1. Login to the application
2. Expire the session/token
3. Trigger an API request
4. Verify the user is redirected to `/login`