### PR TITLE
Fix: Remove redundant landing link from menus

### DIFF
--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -29,7 +29,6 @@ const AdminLayout = () => {
   const navigate = useNavigate();
 
   const adminNavigation = [
-    { name: "Landing", href: "/landing" },
     { name: "Dashboard", href: "/admin" },
     { name: "Users", href: "/admin/users" },
     { name: "Analytics", href: "/admin/analytics" },

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -23,7 +23,6 @@ const MainLayout = () => {
   const { user} = useAuth();
   const userId = (user as any)?.id || "";
   const navigation = [
-    { name: "Landing", href: "/landing" },
     { name: "Home", href: "/dashboard" },
     { name: "Gallery", href: "/gallery" },
     { name: "Upload", href: "/upload" },


### PR DESCRIPTION
### Description

- The navigation currently includes a `Landing` menu option in both Admin and User Page.
- This is unnecessary because the `Beehive logo` already links users to `/landing` (Home Page).

### Expected Behavior
- Users can navigate to `/landing` (Home Page) via the logo only, without a duplicate `Landing` menu item in layout navigation.

### Changes

- This change removes the extra **“Landing”** menu item from the navigation menus.
    - Removed `Landing` item from Both Admin and User Page.
- This Makes the navigation clearer and avoids having the same action twice in the interface.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
