### PR TITLE
Show username instead of user ID in admin notifications and fix notification UI overflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -826,23 +826,46 @@ def get_admin_notifications():
         )
 
         # Enrich notifications with usernames from database
+        # Collect user_ids that need enrichment to avoid N+1 queries
+        user_ids_to_fetch = set()
+        for n in notifications:
+            if "user_id" in n and (not n.get("username") or len(n.get("username", "")) == 24):
+                try:
+                    user_ids_to_fetch.add(ObjectId(n["user_id"]))
+                except Exception as e:
+                    logging.warning(
+                        f"Could not convert user_id {n.get('user_id')} to ObjectId: {e}"
+                    )
+
+        # Batch-fetch users for collected user_ids
+        user_map = {}
+        if user_ids_to_fetch:
+            users_cursor = user_collection.find(
+                {"_id": {"$in": list(user_ids_to_fetch)}},
+                {"username": 1, "email": 1},
+            )
+            for user in users_cursor:
+                user_map[str(user["_id"])] = user
+
+        # Enrich notifications with usernames from database
         for n in notifications:
             n["_id"] = str(n["_id"])
             if "timestamp" in n:
                 n["timestamp"] = n["timestamp"].isoformat()
-            
-            # If username is missing or looks like an ID, fetch from database
-            username = n.get("username")
-            if "user_id" in n and (not username or ObjectId.is_valid(username)):
+
+            # If username is missing or looks like an ID, enrich from pre-fetched users
+            if "user_id" in n and (not n.get("username") or len(n.get("username", "")) == 24):
                 try:
-                    user = user_collection.find_one({"_id": ObjectId(n["user_id"])})
+                    user = user_map.get(str(n["user_id"]))
                     if user and user.get("username"):
                         n["username"] = user["username"]
                     elif user and user.get("email"):
                         # Fallback to email if username not available
                         n["username"] = user["email"].split("@")[0]
                 except Exception as e:
-                    logging.warning(f"Could not fetch username for user_id {n.get('user_id')}: {e}")
+                    logging.warning(
+                        f"Could not enrich username for user_id {n.get('user_id')}: {e}"
+                    )
 
         return jsonify(
             {"notifications": notifications, "unseen_count": unseen_count, "page": page}

--- a/app.py
+++ b/app.py
@@ -832,7 +832,8 @@ def get_admin_notifications():
                 n["timestamp"] = n["timestamp"].isoformat()
             
             # If username is missing or looks like an ID, fetch from database
-            if "user_id" in n and (not n.get("username") or len(n.get("username", "")) == 24):
+            username = n.get("username")
+            if "user_id" in n and (not username or ObjectId.is_valid(username)):
                 try:
                     user = user_collection.find_one({"_id": ObjectId(n["user_id"])})
                     if user and user.get("username"):

--- a/app.py
+++ b/app.py
@@ -804,6 +804,7 @@ def user_images_show():
 def get_admin_notifications():
     try:
         notification_collection = get_beehive_notification_collection()
+        user_collection = get_beehive_user_collection()
 
         try:
             page = int(request.args.get("page", 1))
@@ -824,10 +825,23 @@ def get_admin_notifications():
             .limit(per_page)
         )
 
+        # Enrich notifications with usernames from database
         for n in notifications:
             n["_id"] = str(n["_id"])
             if "timestamp" in n:
                 n["timestamp"] = n["timestamp"].isoformat()
+            
+            # If username is missing or looks like an ID, fetch from database
+            if "user_id" in n and (not n.get("username") or len(n.get("username", "")) == 24):
+                try:
+                    user = user_collection.find_one({"_id": ObjectId(n["user_id"])})
+                    if user and user.get("username"):
+                        n["username"] = user["username"]
+                    elif user and user.get("email"):
+                        # Fallback to email if username not available
+                        n["username"] = user["email"].split("@")[0]
+                except Exception as e:
+                    logging.warning(f"Could not fetch username for user_id {n.get('user_id')}: {e}")
 
         return jsonify(
             {"notifications": notifications, "unseen_count": unseen_count, "page": page}

--- a/app.py
+++ b/app.py
@@ -860,8 +860,8 @@ def get_admin_notifications():
                     if user and user.get("username"):
                         n["username"] = user["username"]
                     elif user and user.get("email"):
-                        # Fallback to email if username not available
-                        n["username"] = user["email"].split("@")[0]
+                        # Fallback to email if username not available; use full email to avoid collisions
+                        n["username"] = user["email"]
                 except Exception as e:
                     logging.warning(
                         f"Could not enrich username for user_id {n.get('user_id')}: {e}"

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -304,11 +304,12 @@ const AdminLayout = () => {
                                     : "bg-yellow-100 dark:bg-yellow-900"
                                 }`}
                               >
-                                <div className="break-words">
+                                <div>
                                   <span className="font-medium break-all">
                                     Image uploaded by {notif.username || "a user"}
                                   </span>
-                                  <span className="break-words">: {notif.title}</span>
+                                  <span>: {notif.title}</span>
+                                </div>
                                 </div>
                                 <div className="text-xs text-gray-500 mt-1">
                                   {notif.timestamp

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -298,17 +298,19 @@ const AdminLayout = () => {
                             {notifications.map((notif, idx) => (
                               <li
                                 key={notif._id || idx}
-                                className={`mb-2 last:mb-0 text-sm rounded-lg p-2 ${
+                                className={`mb-2 last:mb-0 text-sm rounded-lg p-2 break-words ${
                                   notif.seen
                                     ? "bg-transparent"
                                     : "bg-yellow-100 dark:bg-yellow-900"
                                 }`}
                               >
-                                <span className="font-medium">
-                                  Image uploaded by {notif.username || "a user"}
-                                </span>
-                                : {notif.title}
-                                <div className="text-xs text-gray-500">
+                                <div className="break-words">
+                                  <span className="font-medium break-all">
+                                    Image uploaded by {notif.username || "a user"}
+                                  </span>
+                                  <span className="break-words">: {notif.title}</span>
+                                </div>
+                                <div className="text-xs text-gray-500 mt-1">
                                   {notif.timestamp
                                     ? new Date(notif.timestamp).toLocaleString()
                                     : ""}


### PR DESCRIPTION
<img width="1909" height="906" alt="image" src="https://github.com/user-attachments/assets/7dbf5193-c769-431e-8723-c1e65ef4e353" />

## What:

Update admin notifications to display the username or email instead of the raw user ID. Also fix a UI issue where long usernames or emails caused layout overflow in the notification display.

## Why:

Displaying only the user ID makes it difficult for admins to identify which user triggered the notification. Additionally, long emails or usernames were breaking the notification layout, leading to inconsistent UI.

## How:

* Replace the user ID in admin notifications with the user's username or email.
* Adjust the notification UI to properly handle long usernames or emails and prevent overflow.

Closes #553
