### PR TITLE
feat: add rate limiting to auth endpoints

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -12,6 +12,7 @@ from database.userdatahandler import update_last_seen
 from utils.roles import is_admin_email
 from utils.jwt_auth import create_access_token
 from database.databaseConfig import beehive
+from utils.rate_limit import rate_limit
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -71,6 +72,7 @@ def create_email_otp(email: str) -> str:
 
 # REQUEST OTP 
 @auth_bp.route("/request-otp", methods=["POST"])
+@rate_limit(max_requests=3, window_seconds=900)
 def request_otp():
     data = request.get_json(force=True)
     try: 
@@ -119,6 +121,7 @@ def request_otp():
 from datetime import datetime, timezone
 
 @auth_bp.route("/verify-otp", methods=["POST"], strict_slashes=False)
+@rate_limit(max_requests=5, window_seconds=900)
 def verify_otp():
     try:
         data = request.get_json(force=True)
@@ -218,6 +221,7 @@ def complete_signup():
     }), 201
 
 @auth_bp.route("/login", methods=["POST"])
+@rate_limit(max_requests=5, window_seconds=900)
 def login():
     data = request.get_json(force=True)
 

--- a/utils/rate_limit.py
+++ b/utils/rate_limit.py
@@ -5,6 +5,17 @@ from time import time
 
 
 _request_counts = defaultdict(lambda: defaultdict(list))
+_CLEANUP_INTERVAL = 3600
+
+
+def _cleanup_old_entries():
+    current_time = time()
+    for endpoint in list(_request_counts.keys()):
+        for identifier in list(_request_counts[endpoint].keys()):
+            if not _request_counts[endpoint][identifier]:
+                del _request_counts[endpoint][identifier]
+        if not _request_counts[endpoint]:
+            del _request_counts[endpoint]
 
 
 def rate_limit(max_requests=5, window_seconds=900):
@@ -13,7 +24,7 @@ def rate_limit(max_requests=5, window_seconds=900):
         def wrapped(*args, **kwargs):
             identifier = request.remote_addr
             
-            if request.is_json and request.json:
+            if request.is_json and isinstance(request.json, dict):
                 phone = request.json.get('phone')
                 email = request.json.get('email')
                 if phone:
@@ -27,12 +38,19 @@ def rate_limit(max_requests=5, window_seconds=900):
             request_times = _request_counts[endpoint][identifier]
             request_times[:] = [t for t in request_times if current_time - t < window_seconds]
             
+            if not request_times and identifier in _request_counts[endpoint]:
+                del _request_counts[endpoint][identifier]
+            
             if len(request_times) >= max_requests:
                 return jsonify({
                     'error': 'Too many requests. Please try again later.'
                 }), 429
             
             request_times.append(current_time)
+            
+            if int(current_time) % _CLEANUP_INTERVAL == 0:
+                _cleanup_old_entries()
+            
             return f(*args, **kwargs)
         
         return wrapped

--- a/utils/rate_limit.py
+++ b/utils/rate_limit.py
@@ -1,0 +1,39 @@
+from flask import request, jsonify
+from functools import wraps
+from collections import defaultdict
+from time import time
+
+
+_request_counts = defaultdict(lambda: defaultdict(list))
+
+
+def rate_limit(max_requests=5, window_seconds=900):
+    def decorator(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            identifier = request.remote_addr
+            
+            if request.is_json and request.json:
+                phone = request.json.get('phone')
+                email = request.json.get('email')
+                if phone:
+                    identifier = f"phone:{phone}"
+                elif email:
+                    identifier = f"email:{email}"
+            
+            endpoint = request.endpoint
+            current_time = time()
+            
+            request_times = _request_counts[endpoint][identifier]
+            request_times[:] = [t for t in request_times if current_time - t < window_seconds]
+            
+            if len(request_times) >= max_requests:
+                return jsonify({
+                    'error': 'Too many requests. Please try again later.'
+                }), 429
+            
+            request_times.append(current_time)
+            return f(*args, **kwargs)
+        
+        return wrapped
+    return decorator


### PR DESCRIPTION
Adds rate limiting to prevent brute force attacks on authentication endpoints.

## What changed
- Created simple in-memory rate limiter
- Applied to `/request-otp` (3 requests per 15 min)
- Applied to `/verify-otp` (5 attempts per 15 min)
- Applied to `/login` (5 attempts per 15 min)

## Why
Right now there's nothing stopping someone from brute forcing OTPs or hammering the login endpoint. OTP is only 6 digits so brute force is totally doable without rate limiting.

The rate limiter tracks by phone/email for OTP endpoints and by IP for other requests. Cleans up old request timestamps automatically so memory doesn't grow.

## Testing
Tested locally - after hitting the limit you get a 429 error with clear message. Window resets after 15 minutes.
```bash
PS C:\Users\Sahil\Beehive> python test_client.py

======================================================================
TESTING RATE LIMITING
======================================================================
Endpoint: POST /test-rate-limit
Limit: 3 requests per 60 seconds
======================================================================

Request #1
  Status Code: 200
  Response: {'message': 'Success'}
  ✓ Request allowed

Request #2
  Status Code: 200
  Response: {'message': 'Success'}
  ✓ Request allowed

Request #3
  Status Code: 200
  Response: {'message': 'Success'}
  ✓ Request allowed

Request #4
  Status Code: 429
  Response: {'error': 'Too many requests. Please try again later.'}
  ✗ RATE LIMITED - Too many requests!
  ```
First 3 requests passed, request  `#4` was blocked.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
