### PR TITLE
fix: disable debug mode in production

### DIFF
--- a/app.py
+++ b/app.py
@@ -965,5 +965,5 @@ app.register_blueprint(auth_bp, url_prefix="/api/auth")
 initialize_text_index()
 
 if __name__ == "__main__":
-    debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ("true", "1")
+    debug_mode = os.getenv("FLASK_DEBUG", "False").strip().lower() in ("true", "1")
     app.run(debug=debug_mode)

--- a/app.py
+++ b/app.py
@@ -965,4 +965,5 @@ app.register_blueprint(auth_bp, url_prefix="/api/auth")
 initialize_text_index()
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ("true", "1")
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Debug mode was hardcoded to True which exposes stack traces and internal errors to users. Changed to use FLASK_DEBUG environment variable instead.
Defaults to False for production safety.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
