### PR TITLE
Fix: Avoid Insecure OAuth Transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@
 # ============================================================================
 MONGODB_URI=mongodb://localhost:27017/
 DATABASE_NAME=beehive
+FLASK_ENV=development
 
 # ============================================================================
 # REQUIRED: Security & Authentication

--- a/app.py
+++ b/app.py
@@ -154,7 +154,8 @@ if (
 app.config["UPLOAD_FOLDER"] = "static/uploads"
 app.config["PDF_THUMBNAIL_FOLDER"] = "static/uploads/thumbnails/"
 app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024
-os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
+if os.getenv("FLASK_ENV") == "development":
+    os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
 client_secrets_file = os.path.join(pathlib.Path(__file__).parent, "client_secret.json")
 
 


### PR DESCRIPTION
### Summary

- Setting OAUTHLIB_INSECURE_TRANSPORT=1 forces OAuthLib to allow non-HTTPS OAuth flows. In practice, it turns off the safety check that normally blocks token exchange, callback handling, and authorization traffic over plain HTTP.
- It enables credential and token theft via MITM , Without TLS, anyone with network visibility can capture secrets and replay them to impersonate users.

### Changes


- Before
``` python
os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
``` 

- After
``` python
if os.getenv("FLASK_ENV") == "development":
    os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
``` 

### Benefits

- Prevents insecure OAuth flows in production.
- Maintains developer convenience for local testing without HTTPS.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)