### PR TITLE
Update authentication tests to use API endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,7 @@ isort==5.13.2
 pre-commit==4.0.1
 pytest-flask==1.3.0
 colorama==0.4.6
+mongomock==4.3.0
 
 # AI & Magic detection
 google-generativeai==0.8.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,23 @@
 import pytest
 import mongomock
-import unittest.mock
 from unittest.mock import patch
 
-unittest.mock.patch("pymongo.MongoClient", mongomock.MongoClient).start()
-
-from app import app as flask_app
-from database.databaseConfig import db
-
+@pytest.fixture(scope='session', autouse=True)
+def mock_mongo_client_session():
+    with patch('pymongo.MongoClient', mongomock.MongoClient):
+        yield
 
 @pytest.fixture(autouse=True)
-def mock_db():
+def mock_db(mock_mongo_client_session):
+    from database.databaseConfig import db
     # Clear all collections
     for collection in db.list_collection_names():
         db.drop_collection(collection)
     yield db
 
 @pytest.fixture
-def app():
+def app(mock_mongo_client_session):
+    from app import app as flask_app
     flask_app.config.update({
         "TESTING": True,
         "SECRET_KEY": "beehive",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,20 @@
 import pytest
+import mongomock
+import unittest.mock
+from unittest.mock import patch
+
+unittest.mock.patch("pymongo.MongoClient", mongomock.MongoClient).start()
+
 from app import app as flask_app
+from database.databaseConfig import db
+
+
+@pytest.fixture(autouse=True)
+def mock_db():
+    # Clear all collections
+    for collection in db.list_collection_names():
+        db.drop_collection(collection)
+    yield db
 
 @pytest.fixture
 def app():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,42 +1,33 @@
-from database.userdatahandler import get_user_by_username 
+import bcrypt
+import pytest
+from unittest.mock import patch
 
+@pytest.mark.parametrize(
+    "user_data, is_admin, expected_role",
+    [
+        (
+            {"username": "testuser", "email": "test@example.com", "password": "testpassword"},
+            False,
+            "user",
+        ),
+        (
+            {"username": "adminuser", "email": "admin@example.com", "password": "adminpassword"},
+            True,
+            "admin",
+        ),
+    ],
+)
+def test_complete_signup_success(client, mock_db, user_data, is_admin, expected_role):
+    """POST /api/auth/complete-signup for user and admin roles."""
+    with patch("routes.auth.is_admin_email", return_value=is_admin):
+        response = client.post("/api/auth/complete-signup", json=user_data)
 
-def test_register_success(client):
-    """Test successful registration."""
-    response = client.post("/register", data={
-        "firstname": "Test",
-        "lastname": "User",
-        "email": "test123@gmail.com",
-        "username": "testuser123",
-        "password": "password123",
-        "confirm_password": "password123",
-        "security_question": "What is your favorite book?",
-        "security_answer": "1984"
-    }, follow_redirects=True)
-
-    assert response.status_code == 200
-    assert b"Registration successful!" in response.data
-
-    # Check if user was added to the database
-    user = get_user_by_username("testuser123")
+    assert response.status_code == 201
+    data = response.get_json()
+    user = mock_db.users.find_one({"email": user_data["email"]})
     assert user is not None
-    assert user["mail_id"] == "test123@gmail.com"
-
-def test_register_password_mismatch(client):
-    """Test registration failure due to mismatched passwords."""
-    response = client.post("/register", data={
-        "firstname": "Test",
-        "lastname": "User",
-        "email": "testuser@example.com",
-        "username": "testuser123",
-        "password": "password123",
-        "confirm_password": "wrongpassword",
-        "security_question": "What is your favorite book?",
-        "security_answer": "1984"
-    })
-
-    assert response.status_code == 200
-    assert b"Passwords do not match" in response.data
-
-
-
+    assert user["username"] == user_data["username"]
+    assert bcrypt.checkpw(user_data["password"].encode('utf-8'), user["password"])
+    assert "access_token" in data
+    assert "role" in data
+    assert data["role"] == expected_role

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,3 +1,45 @@
-def test_login_page(client):
-    response = client.get('/login')
+import bcrypt
+import pytest
+
+
+@pytest.fixture
+def created_user(mock_db):
+    """Fixture to create a user in the mock database."""
+    password = "securepassword"
+    hashed_pw = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())
+    user_data = {
+        "email": "test@example.com",
+        "username": "testuser",
+        "password": hashed_pw,
+    }
+    mock_db.users.insert_one(user_data)
+    return {"email": user_data["email"], "password": password}
+
+
+def test_login_success(client, created_user):
+    """
+    POST /api/auth/login with valid credentials.
+    """
+    response = client.post(
+        "/api/auth/login",
+        json={
+            "username": created_user["email"],
+            "password": created_user["password"],
+        },
+    )
+
     assert response.status_code == 200
+    data = response.get_json()
+    assert "access_token" in data
+
+
+def test_login_invalid_credentials(client, created_user):
+    """POST /api/auth/login - invalid credentials should return 401"""
+    response = client.post(
+        "/api/auth/login",
+        json={"username": created_user["email"], "password": "wrongpassword"},
+    )
+
+    assert response.status_code == 401
+    data = response.get_json()
+    assert "access_token" not in data

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -13,7 +13,7 @@ def created_user(mock_db):
         "password": hashed_pw,
     }
     mock_db.users.insert_one(user_data)
-    return {"email": user_data["email"], "password": password}
+    return {"email": user_data["email"], "username": user_data["username"], "password": password}
 
 
 @pytest.mark.parametrize("login_identifier_key", ["email", "username"])

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -16,14 +16,15 @@ def created_user(mock_db):
     return {"email": user_data["email"], "password": password}
 
 
-def test_login_success(client, created_user):
+@pytest.mark.parametrize("login_identifier_key", ["email", "username"])
+def test_login_success(client, created_user, login_identifier_key):
     """
-    POST /api/auth/login with valid credentials.
+    POST /api/auth/login with valid credentials (email or username).
     """
     response = client.post(
         "/api/auth/login",
         json={
-            "username": created_user["email"],
+            "username": created_user[login_identifier_key],
             "password": created_user["password"],
         },
     )


### PR DESCRIPTION
## What

This PR updates the authentication tests to match the current Rest API based authentication system. The old HTML form tests for `/register` and `/login` were removed and replaced with tests for `/api/auth/complete-signup` and `/api/auth/login`.

## Why

The authentication flow has moved from server rendered HTML forms to JSON API endpoints, so the existing tests no longer reflected the current behavior.

## How

Added new tests for signup and login API endpoints and used mongomock to mock MongoDB during testing, so testing never requires external databases. This also helps with implementing GitHub Actions CI for testing the source code.

**Checklist:**
- [x ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
