### PR TITLE
Fix: frontend JWT decoding to correctly handle base64url tokens

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { jwtDecode } from "jwt-decode";
 
-interface JwtPayload {
+export interface JwtPayload {
   sub: string;
   role?: "admin" | "user";
   exp?: number;

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { jwtDecode } from "jwt-decode";
 
 interface JwtPayload {
   sub: string;
@@ -27,7 +28,7 @@ function decodeToken(): User | null {
   if (!token) return null;
 
   try {
-    const payload = JSON.parse(atob(token.split(".")[1])) as JwtPayload;
+    const payload = jwtDecode<JwtPayload>(token);
 
     return {
       id: payload.sub,

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -16,6 +16,7 @@ import {
 } from "@heroicons/react/24/outline";
 import toast from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
+import { jwtDecode } from "jwt-decode";
 import { apiUrl } from "../utils/api";
 import useObjectUrl from "../hooks/useObjectUrl";
 import Webcam from "../components/Webcam";
@@ -31,6 +32,10 @@ const allowedFileTypes = [
 ];
 
 type SentimentType = 'positive' | 'neutral' | 'negative' | 'custom';
+
+interface JwtPayload {
+  exp?: number;
+}
 
 const Upload = () => {
   const tokenFromStorage = getToken();
@@ -401,7 +406,7 @@ const Upload = () => {
         return;
       }
       try {
-        const payload = JSON.parse(atob(rawToken.split(".")[1]));
+        const payload = jwtDecode<JwtPayload>(rawToken);
         if (payload.exp && payload.exp * 1000 <= Date.now()) {
           toast.error('Session expired. Redirecting to landing...');
           logout();

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { getToken, logout } from "../utils/auth";
-import { useAuth } from "../hooks/useAuth";
+import { useAuth, type JwtPayload } from "../hooks/useAuth";
 import {
   CloudArrowUpIcon,
   MicrophoneIcon,
@@ -32,10 +32,6 @@ const allowedFileTypes = [
 ];
 
 type SentimentType = 'positive' | 'neutral' | 'negative' | 'custom';
-
-interface JwtPayload {
-  exp?: number;
-}
 
 const Upload = () => {
   const tokenFromStorage = getToken();


### PR DESCRIPTION
### Summary

### Issue
- JWT payload parsing was using raw `atob(...)` on token segments, which assumes standard base64 encoding. JWT uses base64url encoding, so valid tokens containing URL-safe characters could fail to decode. This caused incorrect auth/session behavior such as false "not authenticated" or "session expired" states.

### Changes 
- Replaced manual JWT payload decoding in `useAuth.ts` with `jwtDecode<JwtPayload>(token)` and `Upload.tsx` with `jwtDecode<JwtPayload>(rawtoken)` for expiry check.
- Added a local payload interface in `Upload.tsx` to type the `exp` claim .

### Result
- Auth/session checks now use base64url-safe JWT decoding and no longer fail on valid URL-safe token payloads.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
