### PR TITLE
Fix: undefined logger utility import

### DIFF
--- a/database/admindatahandler.py
+++ b/database/admindatahandler.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from pymongo.errors import PyMongoError
 from flask import session
-
+from utils.logger import logger
 from database import databaseConfig
 
 beehive_admin_collection = databaseConfig.get_beehive_admin_collection()

--- a/database/admindatahandler.py
+++ b/database/admindatahandler.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+
 from pymongo.errors import PyMongoError
 from flask import session
+
 from utils.logger import logger
 from database import databaseConfig
 


### PR DESCRIPTION
### Summary

### Issue

- In admindatahandler.py:22 , the exception path calls `logger.error()` but there is no `logger` imported .
- https://github.com/KathiraveluLab/Beehive/blob/db82dc76f20850f47bd81be334a5ae4b1840b0c5/database/admindatahandler.py#L22
- This turns an expected DB error path into a secondary NameError, masking root cause and breaking failure handling.

### Changes

- imported `logger`


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
