### PR TITLE
refactor: improve get_recent_uploads speed and add MongoDB indexes

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ from flask_mail import Mail
 from database.databaseConfig import (
     get_beehive_message_collection,
     get_beehive_notification_collection,
-    initialize_text_index,
+    initialize_indexes,
 )
 from database.databaseConfig import get_beehive_user_collection
 from database.userdatahandler import (
@@ -963,7 +963,7 @@ from routes.auth import auth_bp
 app.register_blueprint(auth_bp, url_prefix="/api/auth")
 
 # Initialize text index for search functionality
-initialize_text_index()
+initialize_indexes()
 
 if __name__ == "__main__":
     debug_mode = os.getenv("FLASK_DEBUG", "False").strip().lower() in ("true", "1")

--- a/database/admindatahandler.py
+++ b/database/admindatahandler.py
@@ -1,9 +1,7 @@
 from datetime import datetime
-
 from pymongo.errors import PyMongoError
 from flask import session
 
-from utils.logger import logger
 from database import databaseConfig
 
 beehive_admin_collection = databaseConfig.get_beehive_admin_collection()

--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -83,5 +83,25 @@ def initialize_text_index():
                 logger.debug("email_verified_idx already exists on email_otps")
         except Exception as ie:
             logger.error(f"Error creating email_otps index: {ie}")
+
+        # Add image collection indices for efficient recent uploads aggregation
+        if 'created_at_-1' not in existing_indexes:
+            image_collection.create_index([('created_at', -1)])
+            logger.info("Created index on created_at for image collection")
+            
+        if 'user_id_1' not in existing_indexes:
+            image_collection.create_index([('user_id', 1)])
+            logger.info("Created index on user_id for image collection")
+        
+        # Add user collection indices
+        try:
+            user_collection = get_beehive_user_collection()
+            user_indexes = user_collection.index_information()
+            if 'username_1' not in user_indexes:
+                user_collection.create_index([('username', 1)])
+                logger.info("Created index on username for user collection")
+        except Exception as ue:
+            logger.error(f"Error creating user indexes: {ue}")
+            
     except Exception as e:
         logger.error(f"Error creating text index: {str(e)}")

--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -56,7 +56,7 @@ def get_beehive_message_collection():
     return beehive.messages
 
 
-def initialize_text_index():
+def initialize_indexes():
     try:
         image_collection = get_beehive_image_collection()
         existing_indexes = image_collection.index_information()
@@ -84,14 +84,12 @@ def initialize_text_index():
         except Exception as ie:
             logger.error(f"Error creating email_otps index: {ie}")
 
-        # Add image collection indices for efficient recent uploads aggregation
-        if 'created_at_-1' not in existing_indexes:
-            image_collection.create_index([('created_at', -1)])
-            logger.info("Created index on created_at for image collection")
-            
-        if 'user_id_1' not in existing_indexes:
-            image_collection.create_index([('user_id', 1)])
-            logger.info("Created index on user_id for image collection")
+        # Compound index for queries that filter by user_id and sort by created_at.
+        # Also serves queries that only filter by user_id (leftmost prefix rule),
+        # making a separate user_id index redundant.
+        if 'user_id_1_created_at_-1' not in existing_indexes:
+            image_collection.create_index([('user_id', 1), ('created_at', -1)])
+            logger.info("Created compound index (user_id, created_at) for image collection")
         
         # Add user collection indices
         try:
@@ -101,7 +99,7 @@ def initialize_text_index():
                 user_collection.create_index([('username', 1)])
                 logger.info("Created index on username for user collection")
         except Exception as ue:
-            logger.error(f"Error creating user indexes: {ue}")
+            logger.error(f"Error creating user collection indexes: {ue}")
             
     except Exception as e:
-        logger.error(f"Error creating text index: {str(e)}")
+        logger.error(f"Error creating database indexes: {str(e)}")

--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -96,8 +96,8 @@ def initialize_indexes():
             user_collection = get_beehive_user_collection()
             user_indexes = user_collection.index_information()
             if 'username_1' not in user_indexes:
-                user_collection.create_index([('username', 1)])
-                logger.info("Created index on username for user collection")
+                user_collection.create_index([('username', 1)], collation=Collation(locale='en', strength=2))
+                logger.info("Created case-insensitive index on username for user collection")
         except Exception as ue:
             logger.error(f"Error creating user collection indexes: {ue}")
             

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -426,7 +426,7 @@ def get_recent_uploads(limit=10, username_filter=None, from_date=None, end_date=
         # Username filter: Pre-lookup the user IDs to inject into the primary match step
         if username_filter:
             matching_users = list(beehive_user_collection.find(
-                {"username": {"$regex": f"^{re.escape(username_filter)}", "$options": "i"}},
+                {"username": {"$regex": f"^{re.escape(username_filter)}"}},
                 {"_id": 1}
             ))
             user_ids = [u["_id"] for u in matching_users]

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -430,11 +430,11 @@ def get_recent_uploads(limit=10, username_filter=None, from_date=None, end_date=
                 {"_id": 1}
             ))
             user_ids = [u["_id"] for u in matching_users]
-            user_ids_str = [str(u["_id"]) for u in matching_users]
-            match["$or"] = [
-                {"user_id": {"$in": user_ids}},
-                {"user_id": {"$in": user_ids_str}}
-            ]
+            # Since user_id in the images collection is stored as an ObjectId,
+            # we only need to query against that type. An empty $in list
+            # correctly matches no documents if no users are found.
+            match["user_id"] = {"$in": user_ids}
+
 
         if match:
             pipeline.append({"$match": match})

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -5,6 +5,7 @@ import bcrypt
 from flask import session
 from database import databaseConfig
 from utils.logger import Logger
+from pymongo.collation import Collation 
 
 logger = Logger.get_logger("userdatahandler")
 

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -426,7 +426,7 @@ def get_recent_uploads(limit=10, username_filter=None, from_date=None, end_date=
         # Username filter: Pre-lookup the user IDs to inject into the primary match step
         if username_filter:
             matching_users = list(beehive_user_collection.find(
-                {"username": {"$regex": re.escape(username_filter), "$options": "i"}},
+                {"username": {"$regex": f"^{re.escape(username_filter)}", "$options": "i"}},
                 {"_id": 1}
             ))
             user_ids = [u["_id"] for u in matching_users]

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -413,6 +413,8 @@ def get_recent_uploads(limit=10, username_filter=None, from_date=None, end_date=
         pipeline = []
         match = {}
         created_at = {}
+        
+        # Date filters
         if from_date:
             created_at["$gte"] = from_date
         if end_date:
@@ -420,8 +422,23 @@ def get_recent_uploads(limit=10, username_filter=None, from_date=None, end_date=
 
         if created_at:
             match["created_at"] = created_at
+            
+        # Username filter: Pre-lookup the user IDs to inject into the primary match step
+        if username_filter:
+            matching_users = list(beehive_user_collection.find(
+                {"username": {"$regex": re.escape(username_filter), "$options": "i"}},
+                {"_id": 1}
+            ))
+            user_ids = [u["_id"] for u in matching_users]
+            user_ids_str = [str(u["_id"]) for u in matching_users]
+            match["$or"] = [
+                {"user_id": {"$in": user_ids}},
+                {"user_id": {"$in": user_ids_str}}
+            ]
+
         if match:
             pipeline.append({"$match": match})
+            
         pipeline.extend([
             {
                 "$set": {
@@ -446,8 +463,6 @@ def get_recent_uploads(limit=10, username_filter=None, from_date=None, end_date=
             {"$set": {"user_mapping": {"$first": "$user_mapping"}}},
             {"$set": {"username": "$user_mapping.username"}},
         ])
-        if username_filter:
-            pipeline.append({"$match":{"username":{"$regex": re.escape(username_filter), "$options": "i"}}})
         
         sort_criteria = {"created_at": -1} 
         if sort_method == "date_asc":
@@ -459,17 +474,25 @@ def get_recent_uploads(limit=10, username_filter=None, from_date=None, end_date=
         pipeline.append({"$sort": sort_criteria})
 
         pipeline.append({"$limit": limit})
-        result = beehive_image_collection.aggregate(pipeline)
+        
+        result = list(beehive_image_collection.aggregate(pipeline))
+        
         uploads_list = []
         for upload in result:
             user_id = upload.get('user_id')
             user_name = upload.get('username') or "Unknown User"
+            
+            # Handle possible nested datetime
+            created_at_dt = upload.get('created_at')
+            if isinstance(created_at_dt, dict) and '$date' in created_at_dt:
+                created_at_dt = created_at_dt['$date']
+                
             uploads_list.append({
                 'id': str(upload['_id']),
                 'title': upload.get('title', ''),
                 'user': user_name,
                 'user_id': str(user_id) if user_id else None,
-                'timestamp': upload['created_at']['$date'] if isinstance(upload.get('created_at'), dict) else upload.get('created_at'),
+                'timestamp': created_at_dt,
                 'description': upload.get('description', ''),
                 'filename': upload.get('filename', ''),
                 'audio_filename': upload.get('audio_filename', ''),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,17 +7,18 @@ services:
     ports:
       - "5000:5000"
     environment:
-      - FLASK_ENV=development
-      - FLASK_APP=app.py
-      - MONGODB_URI=mongodb://mongo:27017/beehive
-      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
-      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
-      - REDIRECT_URI=${REDIRECT_URI}
-      - ADMIN_EMAILS=${ADMIN_EMAILS}
-      - JWT_SECRET=${JWT_SECRET}
-      - JWT_EXPIRE_HOURS=${JWT_EXPIRE_HOURS}
-      - GOOGLE_API_KEY=${GOOGLE_API_KEY}
-      - FLASK_SECRET_KEY=${FLASK_SECRET_KEY}
+      FLASK_ENV: development
+      FLASK_APP: app.py
+      MONGODB_URI: mongodb://mongo:27017/beehive
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      REDIRECT_URI: ${REDIRECT_URI}
+      ADMIN_EMAILS: ${ADMIN_EMAILS}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXPIRE_HOURS: ${JWT_EXPIRE_HOURS}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY}
+      FLASK_SECRET_KEY: ${FLASK_SECRET_KEY}
+      
       
     depends_on:
       - mongo
@@ -31,6 +32,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      VITE_API_URL: http://172.22.0.4:5173
     depends_on:
       - flask-app
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
     ports:
       - "5173:5173"
     environment:
-      VITE_API_URL: http://172.22.0.4:5173
+      VITE_API_URL: http://localhost:5000
     depends_on:
       - flask-app
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pyparsing==3.2.1
 uritemplate==4.1.1
 rsa==4.9
 pycparser==2.22
-cffi>=2.0.0
+cffi==1.17.1
 
 # Development & Testing tools
 bcrypt==4.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pyparsing==3.2.1
 uritemplate==4.1.1
 rsa==4.9
 pycparser==2.22
-cffi==1.17.1
+cffi>=2.0.0
 
 # Development & Testing tools
 bcrypt==4.2.1


### PR DESCRIPTION
This commit addresses query inefficiencies in the admin dashboard's recent uploads tab:
1. Refactored the recent uploads query to pre-filter users by matching the username before the `$lookup` step in the aggregation pipeline. This prevents full-table lookups on every request and significantly improves query speeds.
2. Added ascending index for `user_id` and descending index for `created_at` in the images collection, and an index for [username]  in the users collection.