### PR TITLE
Fix: user_id mismatch in gallery query

### DIFF
--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -155,13 +155,13 @@ def _parse_iso_date(date_string, field_name):
 def search_and_filter_images(user_id, search_query=None, sentiment=None, from_date=None, to_date=None, 
                              sort_by='date', sort_order='desc', limit=12, offset=0):
     try:
+        user_id_candidates = [user_id]
         try:
-            normalized_user_id = ObjectId(user_id)
+            user_id_candidates.append(ObjectId(user_id))
         except Exception:
-            # Keep compatibility with non-ObjectId legacy user IDs
-            normalized_user_id = user_id
+            pass
 
-        query = {'user_id': normalized_user_id}
+        query = {'user_id': {'$in': user_id_candidates}}
         update_last_seen(user_id)
         if search_query and search_query.strip():
             query['$text'] = {'$search': search_query.strip()}

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -155,13 +155,14 @@ def _parse_iso_date(date_string, field_name):
 def search_and_filter_images(user_id, search_query=None, sentiment=None, from_date=None, to_date=None, 
                              sort_by='date', sort_order='desc', limit=12, offset=0):
     try:
-        user_id_candidates = [user_id]
+        user_id_candidates = {user_id}
         try:
-            user_id_candidates.append(ObjectId(user_id))
-        except Exception:
+            user_id_candidates.add(ObjectId(user_id))
+        except (TypeError, ValueError):
+            # This can happen with legacy string-based user IDs
             pass
 
-        query = {'user_id': {'$in': user_id_candidates}}
+        query = {'user_id': {'$in': list(user_id_candidates)}}
         update_last_seen(user_id)
         if search_query and search_query.strip():
             query['$text'] = {'$search': search_query.strip()}

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -45,8 +45,14 @@ def get_user_by_username(username: str):
 
 # Save image to MongoDB
 def save_image(id, filename, title, description, time_created, audio_filename=None, sentiment=None):
+    try:
+        normalized_user_id = ObjectId(id)
+    except Exception:
+        # Keep compatibility with non-ObjectId legacy user IDs
+        normalized_user_id = id
+
     image = {
-        'user_id': ObjectId(id),
+        'user_id': normalized_user_id,
         'filename': filename,
         'title': title,
         'description': description,
@@ -149,7 +155,13 @@ def _parse_iso_date(date_string, field_name):
 def search_and_filter_images(user_id, search_query=None, sentiment=None, from_date=None, to_date=None, 
                              sort_by='date', sort_order='desc', limit=12, offset=0):
     try:
-        query = {'user_id': user_id}
+        try:
+            normalized_user_id = ObjectId(user_id)
+        except Exception:
+            # Keep compatibility with non-ObjectId legacy user IDs
+            normalized_user_id = user_id
+
+        query = {'user_id': normalized_user_id}
         update_last_seen(user_id)
         if search_query and search_query.strip():
             query['$text'] = {'$search': search_query.strip()}

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -47,7 +47,7 @@ def get_user_by_username(username: str):
 def save_image(id, filename, title, description, time_created, audio_filename=None, sentiment=None):
     try:
         normalized_user_id = ObjectId(id)
-    except Exception:
+    except (TypeError, ValueError):
         # Keep compatibility with non-ObjectId legacy user IDs
         normalized_user_id = id
 

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -280,9 +280,6 @@ const Gallery = () => {
       
       const response = await authenticatedFetch(`/api/user/user_uploads?${params}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
         mode: 'cors',
         signal: abortController.signal
       });

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -350,11 +350,12 @@ const Gallery = () => {
   useEffect(() => {
     if (viewMode === 'rolling') return;
     if (searchQuery || sentiment || fromDate || toDate || sortBy !== 'date' || sortOrder !== 'desc') return; // Disable for search mode
+    if (!hasMore) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
         const target = entries[0];
-        if (target.isIntersecting && !loadingMore && !loading && currentPage < totalPages) {
+        if (target.isIntersecting && !loadingMore && !loading && hasMore && currentPage < totalPages) {
           const nextPage = currentPage + 1;
           fetchUploads(nextPage, true);
         }
@@ -376,7 +377,7 @@ const Gallery = () => {
         observer.unobserve(currentTarget);
       }
     };
-  }, [fetchUploads, currentPage, totalPages, loadingMore, loading, viewMode, searchQuery, sentiment, fromDate, toDate, sortBy, sortOrder]);
+  }, [fetchUploads, currentPage, totalPages, hasMore, loadingMore, loading, viewMode, searchQuery, sentiment, fromDate, toDate, sortBy, sortOrder]);
   
   const handleClearFilters = () => {
     setSearchQuery('');
@@ -1244,7 +1245,7 @@ const Gallery = () => {
             )}
 
             {/* Infinite scroll observer target */}
-            <div ref={observerTarget} className="h-1" />
+            {hasMore && <div ref={observerTarget} className="h-1" />}
 
             {/* End of page indicator */}
             {currentPage >= totalPages && images.length > 0 && (


### PR DESCRIPTION
### Summary

This PR fixes an issue where uploaded images were not visible in the user gallery despite successful uploads.

### Changes
- Dual-Format user_id Query 
    - Gallery query now supports both formats
    - Returns: Old (string) records and New (ObjectId) records

- Consistent user_id Normalization

``` python
try:
    normalized_user_id = ObjectId(user_id)
except:
    normalized_user_id = user_id
```

- Removed Unnecessary GET Header
``` typescript
"Content-Type": "application/json"
```
 
### Files Changed
- `userdatahandler.py`
- `Gallery.tsx`

### Related issues
- fixes #592 

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
