### PR TITLE
feat: account settings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import AboutUs from './pages/AboutUs';
 import PrivacyPolicy from './pages/Privacy';
 import TermsOfService from './pages/TermsofService';
 import ForgotPasswordPage from './pages/auth/ForgotPassword';
+import Settings from './pages/Settings';
 
 function App() {
   return (
@@ -56,6 +57,7 @@ function App() {
               <Route path="/dashboard" element={<Home />} />
               <Route path="/gallery" element={<Gallery />} />
               <Route path="/upload" element={<Upload />} />
+              <Route path="/settings" element={<Settings />} />
             </Route>
           </Route>
 

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -26,6 +26,7 @@ const MainLayout = () => {
     { name: "Home", href: "/dashboard" },
     { name: "Gallery", href: "/gallery" },
     { name: "Upload", href: "/upload" },
+    { name: "Settings", href: "/settings" },
   ];
 
   return (

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,222 @@
+import { useState, useEffect, useCallback } from 'react';
+import { UserCircleIcon, LockClosedIcon, ShieldCheckIcon } from '@heroicons/react/24/outline';
+import { apiUrl } from '../utils/api';
+import { getToken } from '../utils/auth';
+import toast from 'react-hot-toast';
+
+interface UserProfile {
+  username: string;
+  email: string;
+  provider: string;
+  role: string;
+  created_at: string | null;
+  has_password: boolean;
+}
+
+const Settings = () => {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [profileLoading, setProfileLoading] = useState(true);
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordLoading, setPasswordLoading] = useState(false);
+
+  const authFetch = useCallback((path: string, options: RequestInit = {}) => {
+    return fetch(apiUrl(path), {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${getToken()}`,
+        ...options.headers,
+      },
+    });
+  }, []);
+
+  useEffect(() => {
+    authFetch('/api/auth/me')
+      .then((res) => res.json())
+      .then((data) => setProfile(data))
+      .catch(() => toast.error('Failed to load profile'))
+      .finally(() => setProfileLoading(false));
+  }, [authFetch]);
+
+  const handleChangePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (newPassword !== confirmPassword) {
+      toast.error('New passwords do not match');
+      return;
+    }
+    if (newPassword.length < 8) {
+      toast.error('Password must be at least 8 characters');
+      return;
+    }
+
+    setPasswordLoading(true);
+    try {
+      const res = await authFetch('/api/auth/change-password', {
+        method: 'PATCH',
+        body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to change password');
+      }
+      toast.success('Password changed successfully');
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to change password');
+    } finally {
+      setPasswordLoading(false);
+    }
+  };
+
+  const joinedDate = profile?.created_at
+    ? new Date(profile.created_at).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null;
+
+  return (
+    <div className="py-10 px-4">
+      <div className="max-w-2xl mx-auto space-y-8">
+        <h1 className="text-3xl font-bold">Account Settings</h1>
+
+        {/* Profile card */}
+        <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 space-y-4">
+          <div className="flex items-center gap-3 mb-2">
+            <UserCircleIcon className="h-6 w-6 text-yellow-400" />
+            <h2 className="text-xl font-semibold">Profile</h2>
+          </div>
+
+          {profileLoading ? (
+            <div className="space-y-3 animate-pulse">
+              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-48" />
+              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-64" />
+            </div>
+          ) : profile ? (
+            <dl className="divide-y divide-gray-100 dark:divide-gray-700">
+              <div className="py-3 flex justify-between">
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">Username</dt>
+                <dd className="text-sm font-semibold">{profile.username}</dd>
+              </div>
+              <div className="py-3 flex justify-between">
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">Email</dt>
+                <dd className="text-sm">{profile.email}</dd>
+              </div>
+              <div className="py-3 flex justify-between">
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">Sign-in method</dt>
+                <dd>
+                  {profile.provider === 'google' ? (
+                    <span className="inline-flex items-center gap-1.5 text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300 px-2.5 py-1 rounded-full">
+                      <ShieldCheckIcon className="h-3.5 w-3.5" />
+                      Google
+                    </span>
+                  ) : (
+                    <span className="text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 px-2.5 py-1 rounded-full">
+                      Email &amp; Password
+                    </span>
+                  )}
+                </dd>
+              </div>
+              {joinedDate && (
+                <div className="py-3 flex justify-between">
+                  <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">Member since</dt>
+                  <dd className="text-sm">{joinedDate}</dd>
+                </div>
+              )}
+            </dl>
+          ) : (
+            <p className="text-sm text-red-500">Could not load profile.</p>
+          )}
+        </section>
+
+        {/* Change password card — hidden for OAuth users without a password */}
+        {profile && profile.has_password && (
+          <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6">
+            <div className="flex items-center gap-3 mb-6">
+              <LockClosedIcon className="h-6 w-6 text-yellow-400" />
+              <h2 className="text-xl font-semibold">Change Password</h2>
+            </div>
+
+            <form onSubmit={handleChangePassword} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-1" htmlFor="current-password">
+                  Current password
+                </label>
+                <input
+                  id="current-password"
+                  type="password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  required
+                  className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-yellow-400 focus:border-transparent dark:bg-gray-700 dark:text-white transition-colors duration-200"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-1" htmlFor="new-password">
+                  New password
+                </label>
+                <input
+                  id="new-password"
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  required
+                  minLength={8}
+                  className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-yellow-400 focus:border-transparent dark:bg-gray-700 dark:text-white transition-colors duration-200"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-1" htmlFor="confirm-password">
+                  Confirm new password
+                </label>
+                <input
+                  id="confirm-password"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  minLength={8}
+                  className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-yellow-400 focus:border-transparent dark:bg-gray-700 dark:text-white transition-colors duration-200"
+                />
+              </div>
+
+              <div className="pt-2">
+                <button
+                  type="submit"
+                  disabled={passwordLoading}
+                  className="bg-yellow-400 hover:bg-yellow-500 disabled:opacity-50 text-black font-semibold py-2 px-6 rounded-lg transition-colors duration-200"
+                >
+                  {passwordLoading ? 'Saving…' : 'Update Password'}
+                </button>
+              </div>
+            </form>
+          </section>
+        )}
+
+        {/* Info for OAuth users */}
+        {profile && !profile.has_password && (
+          <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6">
+            <div className="flex items-center gap-3 mb-2">
+              <LockClosedIcon className="h-6 w-6 text-yellow-400" />
+              <h2 className="text-xl font-semibold">Password</h2>
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Your account uses Google sign-in. Password management is handled by Google.
+            </p>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Settings;

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -400,6 +400,29 @@ def google_auth():
     }), 200
 
 
+@auth_bp.route("/me", methods=["GET"])
+@require_auth
+def get_current_user():
+    """Return the authenticated user's profile information."""
+    try:
+        user_id = ObjectId(request.current_user["id"])
+    except InvalidId:
+        return jsonify({"error": "Invalid user"}), 400
+
+    user = db.users.find_one({"_id": user_id})
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    return jsonify({
+        "username": user.get("username", ""),
+        "email": user.get("email", ""),
+        "provider": user.get("provider", "local"),
+        "role": user.get("role", "user"),
+        "created_at": user.get("created_at").isoformat() if user.get("created_at") else None,
+        "has_password": bool(user.get("password")),
+    }), 200
+
+
 @auth_bp.route("/change-password", methods=["PATCH"])
 @require_auth
 def change_password():

--- a/tests/test_me_endpoint.py
+++ b/tests/test_me_endpoint.py
@@ -1,0 +1,107 @@
+"""
+Tests for GET /api/auth/me endpoint.
+
+Verifies that authenticated users can retrieve their own profile information.
+"""
+from datetime import datetime, timezone
+
+import pytest
+from bson import ObjectId
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+USER_ID = str(ObjectId())
+
+
+def _make_token(app, user_id=USER_ID, role="user"):
+    with app.app_context():
+        from utils.jwt_auth import create_access_token
+
+        return create_access_token(user_id, role)
+
+
+def _get(client, token=None):
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    return client.get("/api/auth/me", headers=headers)
+
+
+def _insert_user(mock_db, user_id=USER_ID, provider="local", has_password=True):
+    import bcrypt
+
+    user = {
+        "_id": ObjectId(user_id),
+        "username": "testuser",
+        "email": "test@example.com",
+        "role": "user",
+        "provider": provider,
+        "created_at": datetime(2025, 1, 1, tzinfo=timezone.utc),
+    }
+    if has_password:
+        user["password"] = bcrypt.hashpw(b"password123", bcrypt.gensalt())
+    mock_db.users.insert_one(user)
+
+
+# ---------------------------------------------------------------------------
+# Tests — authentication guard
+# ---------------------------------------------------------------------------
+
+
+def test_me_no_token(client):
+    """Request without Authorization header must return 401."""
+    resp = _get(client)
+    assert resp.status_code == 401
+
+
+def test_me_invalid_token(client):
+    """Request with a bogus token must return 401."""
+    resp = _get(client, token="not.a.valid.token")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Tests — successful profile retrieval
+# ---------------------------------------------------------------------------
+
+
+def test_me_returns_profile(client, app, mock_db):
+    """Authenticated user receives their profile data."""
+    _insert_user(mock_db)
+    token = _make_token(app)
+    resp = _get(client, token)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["username"] == "testuser"
+    assert data["email"] == "test@example.com"
+    assert data["provider"] == "local"
+    assert data["role"] == "user"
+    assert data["has_password"] is True
+    assert data["created_at"] is not None
+
+
+def test_me_password_not_exposed(client, app, mock_db):
+    """The hashed password must never appear in the response."""
+    _insert_user(mock_db)
+    token = _make_token(app)
+    resp = _get(client, token)
+    assert "password" not in resp.get_json()
+
+
+def test_me_google_user(client, app, mock_db):
+    """Google OAuth users have provider='google' and has_password=False."""
+    _insert_user(mock_db, provider="google", has_password=False)
+    token = _make_token(app)
+    resp = _get(client, token)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["provider"] == "google"
+    assert data["has_password"] is False
+
+
+def test_me_user_not_found(client, app):
+    """Token referencing a non-existent user returns 404."""
+    token = _make_token(app, user_id=str(ObjectId()))
+    resp = _get(client, token)
+    assert resp.status_code == 404


### PR DESCRIPTION
## Account Settings Page

The change-password endpoint was merged but users had no way to reach it
from the app. This PR builds the full account settings
experience end to end.

### What's in this PR

**`GET /api/auth/me` — new profile endpoint**
Returns the authenticated user's username, email, sign-in provider, role,
join date, and a `has_password` flag. The password hash never leaves the
server — the flag simply tells the frontend whether to show the
change-password form.

**`/settings` — new page**
Two sections:
- *Profile* — shows username, email, a badge for the sign-in method
  (Google vs email/password), and the date the account was created.
- *Change Password* — visible only for accounts with a local password.
  Google OAuth users see a short note explaining that their password is
  managed by Google, so they're never shown a form that wouldn't work
  for them.

**Navigation**
Settings is now linked in both the desktop nav bar and the mobile sidebar
so it's actually discoverable.

**Tests**
Six new tests for the `/api/auth/me` endpoint: missing token, invalid
token, successful profile fetch, confirmation that the password hash isn't
returned, correct `has_password: false` flag for OAuth accounts, and 404
for a non-existent user ID.

### Test plan

- [x] Sign in with an email/password account → `/settings` shows profile
      info and the change-password form
- [x] Enter wrong current password → error toast shown
- [x] Enter mismatched new passwords → client-side validation catches it
      before the request fires
- [x] Change password successfully → success toast, fields clear
- [x] Sign in with Google → `/settings` shows profile info and the Google
      note, no password form
- [x] `pytest tests/test_me_endpoint.py` — all 6 pass