### PR TITLE
feat: account lockout

### DIFF
--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -616,6 +616,93 @@ def save_notification(user_id, username, filename, title, time_created, sentimen
     beehive_notification_collection.insert_one(notification)
 
 
+MAX_FAILED_ATTEMPTS = 5
+LOCKOUT_DURATION_MINUTES = 15
+
+
+def get_lock_status(user_id):
+    """Return lock info for a user: is_locked, remaining_seconds, failed_attempts."""
+    try:
+        uid = user_id if isinstance(user_id, ObjectId) else ObjectId(user_id)
+    except (InvalidId, TypeError):
+        return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": 0}
+
+    user = beehive_user_collection.find_one(
+        {"_id": uid},
+        {"failed_login_attempts": 1, "locked_until": 1}
+    )
+    if not user:
+        return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": 0}
+
+    locked_until = user.get("locked_until")
+    now = datetime.now(timezone.utc)
+
+    if locked_until and locked_until.replace(tzinfo=timezone.utc) > now:
+        remaining = int((locked_until.replace(tzinfo=timezone.utc) - now).total_seconds())
+        return {
+            "is_locked": True,
+            "remaining_seconds": remaining,
+            "failed_attempts": user.get("failed_login_attempts", 0),
+        }
+    return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": user.get("failed_login_attempts", 0)}
+
+
+def increment_failed_attempts(user_id):
+    """Increment failed login counter; lock the account if threshold is reached.
+
+    Returns the new failed attempt count.
+    """
+    try:
+        uid = user_id if isinstance(user_id, ObjectId) else ObjectId(user_id)
+    except (InvalidId, TypeError):
+        return 0
+
+    result = beehive_user_collection.find_one_and_update(
+        {"_id": uid},
+        {"$inc": {"failed_login_attempts": 1}},
+        return_document=True,
+        projection={"failed_login_attempts": 1},
+    )
+    if not result:
+        return 0
+
+    new_count = result.get("failed_login_attempts", 0)
+    if new_count >= MAX_FAILED_ATTEMPTS:
+        locked_until = datetime.now(timezone.utc) + timedelta(minutes=LOCKOUT_DURATION_MINUTES)
+        beehive_user_collection.update_one(
+            {"_id": uid},
+            {"$set": {"locked_until": locked_until}},
+        )
+    return new_count
+
+
+def reset_failed_attempts(user_id):
+    """Clear the failed login counter and any lockout on successful authentication."""
+    try:
+        uid = user_id if isinstance(user_id, ObjectId) else ObjectId(user_id)
+    except (InvalidId, TypeError):
+        return
+
+    beehive_user_collection.update_one(
+        {"_id": uid},
+        {"$unset": {"failed_login_attempts": "", "locked_until": ""}},
+    )
+
+
+def unlock_account(user_id):
+    """Admin action: remove lockout and reset failed attempts. Returns True if user found."""
+    try:
+        uid = user_id if isinstance(user_id, ObjectId) else ObjectId(user_id)
+    except (InvalidId, TypeError):
+        return False
+
+    result = beehive_user_collection.update_one(
+        {"_id": uid},
+        {"$unset": {"failed_login_attempts": "", "locked_until": ""}},
+    )
+    return result.matched_count > 0
+
+
 def get_all_users():
     users = beehive_user_collection.find({}, {'_id': 1, 'username': 1})
     return list(users)

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -627,36 +627,46 @@ MAX_FAILED_ATTEMPTS = 5
 LOCKOUT_DURATION_MINUTES = 15
 
 
-def get_lock_status(user_id):
-    """Return lock info for a user: is_locked, remaining_seconds, failed_attempts."""
-    try:
-        uid = user_id if isinstance(user_id, ObjectId) else ObjectId(user_id)
-    except (InvalidId, TypeError):
-        return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": 0}
+def get_lock_status(user_id_or_doc, now=None):
+    """Return lock info for a user: is_locked, remaining_seconds, failed_attempts.
 
-    user = beehive_user_collection.find_one(
-        {"_id": uid},
-        {"failed_login_attempts": 1, "locked_until": 1}
-    )
+    Accepts either a user ID (str or ObjectId) or an already-fetched user
+    document (dict), avoiding a redundant DB query when the caller has the
+    document in hand.  An optional ``now`` datetime can be injected for testing.
+    """
+    if isinstance(user_id_or_doc, dict):
+        user = user_id_or_doc
+    else:
+        try:
+            uid = user_id_or_doc if isinstance(user_id_or_doc, ObjectId) else ObjectId(user_id_or_doc)
+        except (InvalidId, TypeError):
+            return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": 0}
+        user = beehive_user_collection.find_one(
+            {"_id": uid},
+            {"failed_login_attempts": 1, "locked_until": 1}
+        )
+
     if not user:
         return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": 0}
 
     locked_until = user.get("locked_until")
-    now = datetime.now(timezone.utc)
+    if now is None:
+        now = datetime.now(timezone.utc)
 
     locked_until_aware = (
         locked_until if locked_until and locked_until.tzinfo is not None
         else locked_until.replace(tzinfo=timezone.utc) if locked_until
         else None
     )
+    failed_attempts = user.get("failed_login_attempts", 0)
     if locked_until_aware and locked_until_aware > now:
         remaining = int((locked_until_aware - now).total_seconds())
         return {
             "is_locked": True,
             "remaining_seconds": remaining,
-            "failed_attempts": user.get("failed_login_attempts", 0),
+            "failed_attempts": failed_attempts,
         }
-    return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": user.get("failed_login_attempts", 0)}
+    return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": failed_attempts}
 
 
 def increment_failed_attempts(user_id):

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -660,7 +660,7 @@ def get_lock_status(user_id_or_doc, now=None):
     )
     failed_attempts = user.get("failed_login_attempts", 0)
     if locked_until_aware and locked_until_aware > now:
-        remaining = int((locked_until_aware - now).total_seconds())
+        remaining = int((locked_until_aware - now).total_seconds() + 1)
         return {
             "is_locked": True,
             "remaining_seconds": remaining,

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -644,16 +644,18 @@ def get_lock_status(user_id):
     locked_until = user.get("locked_until")
     now = datetime.now(timezone.utc)
 
-    if locked_until:
-        locked_until_aware = locked_until.replace(tzinfo=timezone.utc)
-        if locked_until_aware > now:
-            remaining = int((locked_until_aware - now).total_seconds())
-            return {
-                "is_locked": True,
-                "remaining_seconds": remaining,
-                "failed_attempts": user.get("failed_login_attempts", 0),
-            }
-
+    locked_until_aware = (
+        locked_until if locked_until and locked_until.tzinfo is not None
+        else locked_until.replace(tzinfo=timezone.utc) if locked_until
+        else None
+    )
+    if locked_until_aware and locked_until_aware > now:
+        remaining = int((locked_until_aware - now).total_seconds())
+        return {
+            "is_locked": True,
+            "remaining_seconds": remaining,
+            "failed_attempts": user.get("failed_login_attempts", 0),
+        }
     return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": user.get("failed_login_attempts", 0)}
 
 

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -644,13 +644,16 @@ def get_lock_status(user_id):
     locked_until = user.get("locked_until")
     now = datetime.now(timezone.utc)
 
-    if locked_until and locked_until.replace(tzinfo=timezone.utc) > now:
-        remaining = int((locked_until.replace(tzinfo=timezone.utc) - now).total_seconds())
-        return {
-            "is_locked": True,
-            "remaining_seconds": remaining,
-            "failed_attempts": user.get("failed_login_attempts", 0),
-        }
+    if locked_until:
+        locked_until_aware = locked_until.replace(tzinfo=timezone.utc)
+        if locked_until_aware > now:
+            remaining = int((locked_until_aware - now).total_seconds())
+            return {
+                "is_locked": True,
+                "remaining_seconds": remaining,
+                "failed_attempts": user.get("failed_login_attempts", 0),
+            }
+
     return {"is_locked": False, "remaining_seconds": 0, "failed_attempts": user.get("failed_login_attempts", 0)}
 
 

--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -7,6 +7,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   ArrowDownTrayIcon,
+  LockOpenIcon,
 } from '@heroicons/react/24/outline';
 import toast from 'react-hot-toast';
 import { apiUrl } from '../../utils/api';
@@ -20,6 +21,8 @@ interface User {
   lastActive: string;
   status: string;
   image: string;
+  isLocked: boolean;
+  failedAttempts: number;
 }
 
 const Users = () => {
@@ -79,8 +82,24 @@ const Users = () => {
   };
 
   const handleUserClick = (name: string) => {
-    // redirect to dashboard with user filter in query string
     navigate(`/admin?user=${encodeURIComponent(name)}`);
+  };
+
+  const handleUnlockUser = async (userId: string) => {
+    try {
+      const res = await fetch(apiUrl(`/api/admin/users/${userId}/unlock`), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+      if (!res.ok) throw new Error('Failed to unlock');
+      toast.success('Account unlocked');
+      fetchUsers();
+    } catch {
+      toast.error('Failed to unlock account');
+    }
   };
 
   const handleDownloadCSV = () => {
@@ -231,7 +250,21 @@ const Users = () => {
                           </span>
                         </td> */}
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                          <div className="flex justify-end space-x-3">
+                          <div className="flex justify-end items-center space-x-3">
+                            {user.isLocked && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-200">
+                                Locked
+                              </span>
+                            )}
+                            {user.isLocked && (
+                              <button
+                                onClick={() => handleUnlockUser(user.id)}
+                                className="text-orange-500 hover:text-orange-700 transition-colors duration-200"
+                                title="Unlock Account"
+                              >
+                                <LockOpenIcon className="h-5 w-5" />
+                              </button>
+                            )}
                             <button
                               onClick={() => handleViewUploads(user.id)}
                               className="text-gray-600 hover:text-yellow-400 dark:text-gray-400 transition-colors duration-200"
@@ -239,17 +272,6 @@ const Users = () => {
                             >
                               <PhotoIcon className="h-5 w-5" />
                             </button>
-                            {/* <button
-                              onClick={() => handleToggleStatus(user.id)}
-                              className={`${
-                                user.status === 'active'
-                                  ? 'text-green-600 hover:text-green-700'
-                                  : 'text-red-600 hover:text-red-700'
-                              } transition-colors duration-200`}
-                              title="Toggle Status"
-                            >
-                              <div className="h-5 w-5 rounded-full border-2 border-current" />
-                            </button> */}
                           </div>
                         </td>
                       </tr>

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -9,7 +9,7 @@ const SignInPage = () => {
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
+  const [showPassword, setShowPassword] = useState(false); // State for visibility
   const [error, setError] = useState("");
   const [isLocked, setIsLocked] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { saveToken, getUserRole } from "../../utils/auth";
 import { apiFetch } from "../../utils/apiFetch";
+import { API_BASE_URL } from "../../utils/api";
 import { GoogleLogin } from "@react-oauth/google";
 
 const SignInPage = () => {
@@ -9,28 +10,42 @@ const SignInPage = () => {
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false); // State for visibility
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
+  const [isLocked, setIsLocked] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+    setIsLocked(false);
     setLoading(true);
 
     try {
-      const data = await apiFetch("/api/auth/login", {
+      const res = await fetch(`${API_BASE_URL}/api/auth/login`, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, password }),
       });
 
-      const token = data.access_token;
-      saveToken(token);
+      const data = await res.json();
 
+      if (res.status === 429) {
+        setIsLocked(true);
+        setError(data.error || "Account temporarily locked. Please try again later.");
+        return;
+      }
+
+      if (!res.ok) {
+        setError(data.error || "Invalid credentials");
+        return;
+      }
+
+      saveToken(data.access_token);
       const role = getUserRole();
       navigate(role === "admin" ? "/admin" : "/dashboard");
-    } catch (err: any) {
-      setError(err.message || "Invalid credentials");
+    } catch {
+      setError("Unable to connect. Please check your connection and try again.");
     } finally {
       setLoading(false);
     }
@@ -48,7 +63,12 @@ const SignInPage = () => {
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-lg text-sm text-center">
+            <div className={`border px-4 py-3 rounded-lg text-sm text-center ${
+              isLocked
+                ? "bg-orange-50 border-orange-300 text-orange-700"
+                : "bg-red-50 border-red-200 text-red-600"
+            }`}>
+              {isLocked && <span className="font-semibold block mb-0.5">Account Locked</span>}
               {error}
             </div>
           )}

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { saveToken, getUserRole } from "../../utils/auth";
 import { apiFetch } from "../../utils/apiFetch";
-import { API_BASE_URL } from "../../utils/api";
 import { GoogleLogin } from "@react-oauth/google";
 
 const SignInPage = () => {
@@ -22,30 +21,23 @@ const SignInPage = () => {
     setLoading(true);
 
     try {
-      const res = await fetch(`${API_BASE_URL}/api/auth/login`, {
+      const data = await apiFetch("/api/auth/login", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, password }),
       });
-
-      const data = await res.json();
-
-      if (res.status === 429) {
-        setIsLocked(true);
-        setError(data.error || "Account temporarily locked. Please try again later.");
-        return;
-      }
-
-      if (!res.ok) {
-        setError(data.error || "Invalid credentials");
-        return;
-      }
 
       saveToken(data.access_token);
       const role = getUserRole();
       navigate(role === "admin" ? "/admin" : "/dashboard");
-    } catch {
-      setError("Unable to connect. Please check your connection and try again.");
+    } catch (err: any) {
+      if (err.status === 429) {
+        setIsLocked(true);
+        setError(err.message || "Account temporarily locked. Please try again later.");
+      } else if (err.status) {
+        setError(err.message || "Invalid credentials");
+      } else {
+        setError("Unable to connect. Please check your connection and try again.");
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/utils/apiFetch.ts
+++ b/frontend/src/utils/apiFetch.ts
@@ -29,12 +29,15 @@ export async function apiFetch(
   }
 
   if (!res.ok) {
-    throw new Error(
+    const err = new Error(
       data?.error ||
       data?.message ||
       rawText ||
       `Request failed (${res.status})`
-    );
+    ) as Error & { status: number; data: any };
+    err.status = res.status;
+    err.data = data;
+    throw err;
   }
 
   return data;

--- a/routes/adminroutes.py
+++ b/routes/adminroutes.py
@@ -138,13 +138,7 @@ def list_users():
         now = datetime.now(timezone.utc)
         users = []
         for u in cursor:
-            locked_until = u.get("locked_until")
-            locked_until_aware = (
-                locked_until if locked_until and locked_until.tzinfo is not None
-                else locked_until.replace(tzinfo=timezone.utc) if locked_until
-                else None
-            )
-            is_locked = bool(locked_until_aware and locked_until_aware > now)
+            lock = get_lock_status(u, now=now)
             users.append({
                 "id": str(u.get("_id")),
                 "user_id": str(u.get("_id")),
@@ -153,8 +147,8 @@ def list_users():
                 "lastActive": u.get("last_active") or u.get("last_seen") or None,
                 "status": u.get("status", "active"),
                 "image": u.get("avatar_url", ""),
-                "isLocked": is_locked,
-                "failedAttempts": u.get("failed_login_attempts", 0),
+                "isLocked": lock["is_locked"],
+                "failedAttempts": lock["failed_attempts"],
             })
 
         return jsonify({"users": users, "totalCount": total_count}), 200

--- a/routes/adminroutes.py
+++ b/routes/adminroutes.py
@@ -7,8 +7,10 @@ from database.userdatahandler import (
     get_recent_uploads,
     get_upload_stats,
     get_upload_analytics,
-    get_user_analytics
+    get_user_analytics,
+    unlock_account,
 )
+from datetime import timezone
 from utils.pagination import parse_pagination_params
 from utils.logger import Logger
 from utils.sanitize import sanitize_api_query
@@ -125,8 +127,13 @@ def list_users():
 
         cursor = users_col.find(mongo_filter).skip(offset).limit(limit)
 
+        now = datetime.now(timezone.utc)
         users = []
         for u in cursor:
+            locked_until = u.get("locked_until")
+            is_locked = bool(
+                locked_until and locked_until.replace(tzinfo=timezone.utc) > now
+            )
             users.append({
                 "id": str(u.get("_id")),
                 "user_id": str(u.get("_id")),
@@ -135,12 +142,27 @@ def list_users():
                 "lastActive": u.get("last_active") or u.get("last_seen") or None,
                 "status": u.get("status", "active"),
                 "image": u.get("avatar_url", ""),
+                "isLocked": is_locked,
+                "failedAttempts": u.get("failed_login_attempts", 0),
             })
 
         return jsonify({"users": users, "totalCount": total_count}), 200
     except Exception:
         logger.error("Error listing users", exc_info=True)
         return jsonify({"error": "Failed to list users"}), 500
+
+
+@admin_bp.route("/users/<user_id>/unlock", methods=["POST"])
+@require_admin_role
+def unlock_user(user_id):
+    try:
+        success = unlock_account(user_id)
+        if success:
+            return jsonify({"message": "Account unlocked successfully"}), 200
+        return jsonify({"error": "User not found"}), 404
+    except Exception:
+        logger.error("Error unlocking user account", exc_info=True)
+        return jsonify({"error": "Failed to unlock account"}), 500
 
 
 @admin_bp.route("/users/only-users", methods=["GET"])

--- a/routes/adminroutes.py
+++ b/routes/adminroutes.py
@@ -9,6 +9,7 @@ from database.userdatahandler import (
     get_upload_analytics,
     get_user_analytics,
     unlock_account,
+    get_lock_status,
 )
 from datetime import timezone
 from utils.pagination import parse_pagination_params

--- a/routes/adminroutes.py
+++ b/routes/adminroutes.py
@@ -138,9 +138,12 @@ def list_users():
         users = []
         for u in cursor:
             locked_until = u.get("locked_until")
-            is_locked = bool(
-                locked_until and locked_until.replace(tzinfo=timezone.utc) > now
+            locked_until_aware = (
+                locked_until if locked_until and locked_until.tzinfo is not None
+                else locked_until.replace(tzinfo=timezone.utc) if locked_until
+                else None
             )
+            is_locked = bool(locked_until_aware and locked_until_aware > now)
             users.append({
                 "id": str(u.get("_id")),
                 "user_id": str(u.get("_id")),

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -252,7 +252,7 @@ def login():
         return jsonify({"error": "User not found"}), 401
 
     # Check account lockout before touching the password
-    lock = get_lock_status(user["_id"])
+    lock = get_lock_status(user)
     if lock["is_locked"]:
         mins = lock["remaining_seconds"] // 60
         secs = lock["remaining_seconds"] % 60

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -11,7 +11,14 @@ from bson.errors import InvalidId
 
 from utils.validation import validate_email, validate_otp, sanitize_string, ValidationError
 from database.databaseConfig import db
-from database.userdatahandler import update_last_seen
+from database.userdatahandler import (
+    update_last_seen,
+    get_lock_status,
+    increment_failed_attempts,
+    reset_failed_attempts,
+    MAX_FAILED_ATTEMPTS,
+    LOCKOUT_DURATION_MINUTES,
+)
 from utils.roles import is_admin_email
 from utils.jwt_auth import create_access_token, require_auth
 from database.databaseConfig import beehive
@@ -244,13 +251,36 @@ def login():
     if not user:
         return jsonify({"error": "User not found"}), 401
 
+    # Check account lockout before touching the password
+    lock = get_lock_status(user["_id"])
+    if lock["is_locked"]:
+        mins = lock["remaining_seconds"] // 60
+        secs = lock["remaining_seconds"] % 60
+        return jsonify({
+            "error": f"Account locked. Try again in {mins}m {secs}s.",
+            "locked": True,
+            "remaining_seconds": lock["remaining_seconds"],
+        }), 429
+
     stored_password = user.get("password")
     if not stored_password:
         return jsonify({"error": "Password not set"}), 400
 
     if not bcrypt.checkpw(password.encode(), stored_password):
-        return jsonify({"error": "Invalid credentials"}), 401
+        new_count = increment_failed_attempts(user["_id"])
+        attempts_left = MAX_FAILED_ATTEMPTS - new_count
+        if attempts_left <= 0:
+            return jsonify({
+                "error": f"Account locked due to too many failed attempts. Try again in {LOCKOUT_DURATION_MINUTES} minutes.",
+                "locked": True,
+                "remaining_seconds": LOCKOUT_DURATION_MINUTES * 60,
+            }), 429
+        return jsonify({
+            "error": f"Invalid credentials. {attempts_left} attempt{'s' if attempts_left != 1 else ''} remaining before lockout.",
+        }), 401
 
+    # Successful login — clear any previous failed attempts
+    reset_failed_attempts(user["_id"])
     token = create_access_token(
         user_id=str(user["_id"]),
         role=user.get("role", "user")

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -249,7 +249,7 @@ def login():
     })
 
     if not user:
-        return jsonify({"error": "User not found"}), 401
+        return jsonify({"error": "Invalid credentials"}), 401
 
     # Check account lockout before touching the password
     lock = get_lock_status(user)

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -262,6 +262,12 @@ def login():
             "remaining_seconds": lock["remaining_seconds"],
         }), 429
 
+    # Lockout expired but counter still sits at the threshold — reset it so
+    # the user gets a fresh set of attempts rather than locking out immediately
+    # on the next wrong password.
+    if lock["failed_attempts"] >= MAX_FAILED_ATTEMPTS:
+        reset_failed_attempts(user["_id"])
+
     stored_password = user.get("password")
     if not stored_password:
         return jsonify({"error": "Password not set"}), 400

--- a/tests/test_account_lockout.py
+++ b/tests/test_account_lockout.py
@@ -1,0 +1,202 @@
+"""Tests for account lockout after repeated failed login attempts."""
+import pytest
+import bcrypt
+from datetime import datetime, timezone
+from bson import ObjectId
+from database.userdatahandler import (
+    MAX_FAILED_ATTEMPTS,
+    LOCKOUT_DURATION_MINUTES,
+    get_lock_status,
+    increment_failed_attempts,
+    reset_failed_attempts,
+    unlock_account,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PASSWORD = "testpassword1"
+
+
+def _insert_user(mock_db, username="lockuser", password=PASSWORD, role="user"):
+    hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt())
+    result = mock_db.users.insert_one({
+        "username": username,
+        "email": f"{username}@test.com",
+        "password": hashed,
+        "role": role,
+        "created_at": datetime.now(timezone.utc),
+        "last_active": datetime.now(timezone.utc),
+    })
+    return result.inserted_id
+
+
+def _login(client, username, password=PASSWORD):
+    return client.post("/api/auth/login", json={"username": username, "password": password})
+
+
+def _admin_token(app, mock_db):
+    uid = _insert_user(mock_db, username="adminuser", role="admin")
+    with app.app_context():
+        from utils.jwt_auth import create_access_token
+        return create_access_token(str(uid), "admin")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — DB helpers
+# ---------------------------------------------------------------------------
+
+def test_fresh_user_not_locked(mock_db):
+    uid = _insert_user(mock_db, "freshuser")
+    status = get_lock_status(str(uid))
+    assert status["is_locked"] is False
+    assert status["failed_attempts"] == 0
+
+
+def test_increment_tracks_count(mock_db):
+    uid = _insert_user(mock_db, "countuser")
+    assert increment_failed_attempts(str(uid)) == 1
+    assert increment_failed_attempts(str(uid)) == 2
+    assert get_lock_status(str(uid))["failed_attempts"] == 2
+
+
+def test_account_locks_at_threshold(mock_db):
+    uid = _insert_user(mock_db, "lockthreshold")
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        increment_failed_attempts(str(uid))
+    status = get_lock_status(str(uid))
+    assert status["is_locked"] is True
+    assert status["remaining_seconds"] > 0
+
+
+def test_reset_clears_counter_and_lock(mock_db):
+    uid = _insert_user(mock_db, "resetuser")
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        increment_failed_attempts(str(uid))
+    assert get_lock_status(str(uid))["is_locked"] is True
+    reset_failed_attempts(str(uid))
+    status = get_lock_status(str(uid))
+    assert status["is_locked"] is False
+    assert status["failed_attempts"] == 0
+
+
+def test_unlock_account_clears_lock(mock_db):
+    uid = _insert_user(mock_db, "unlockuser")
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        increment_failed_attempts(str(uid))
+    assert get_lock_status(str(uid))["is_locked"] is True
+    assert unlock_account(str(uid)) is True
+    assert get_lock_status(str(uid))["is_locked"] is False
+
+
+def test_unlock_nonexistent_user_returns_false():
+    assert unlock_account(str(ObjectId())) is False
+
+
+def test_get_lock_status_invalid_id():
+    status = get_lock_status("not-an-objectid")
+    assert status["is_locked"] is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — login endpoint
+# ---------------------------------------------------------------------------
+
+def test_wrong_password_shows_attempts_remaining(client, mock_db):
+    _insert_user(mock_db, "warnuser")
+    res = _login(client, "warnuser", "wrongpassword")
+    assert res.status_code == 401
+    assert "remaining" in res.get_json()["error"].lower()
+
+
+def test_counter_decrements_warning_on_each_failure(client, mock_db):
+    _insert_user(mock_db, "countdownuser")
+    for i in range(1, MAX_FAILED_ATTEMPTS):
+        res = _login(client, "countdownuser", "wrong")
+        assert res.status_code == 401
+        assert str(MAX_FAILED_ATTEMPTS - i) in res.get_json()["error"]
+
+
+def test_fifth_failure_returns_429(client, mock_db):
+    _insert_user(mock_db, "lockme")
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        res = _login(client, "lockme", "wrong")
+    assert res.status_code == 429
+    data = res.get_json()
+    assert data["locked"] is True
+    assert "remaining_seconds" in data
+
+
+def test_locked_account_blocks_correct_password(client, mock_db):
+    _insert_user(mock_db, "blockeduser", password="correctpass")
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        _login(client, "blockeduser", "wrong")
+    res = _login(client, "blockeduser", "correctpass")
+    assert res.status_code == 429
+    assert res.get_json()["locked"] is True
+
+
+def test_successful_login_resets_failed_counter(client, mock_db):
+    uid = _insert_user(mock_db, "resetonlogin", password="goodpass")
+    _login(client, "resetonlogin", "wrong")
+    _login(client, "resetonlogin", "wrong")
+    assert get_lock_status(str(uid))["failed_attempts"] == 2
+    res = _login(client, "resetonlogin", "goodpass")
+    assert res.status_code == 200
+    assert get_lock_status(str(uid))["failed_attempts"] == 0
+
+
+def test_lockout_response_includes_remaining_seconds(client, mock_db):
+    _insert_user(mock_db, "timedlock")
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        _login(client, "timedlock", "wrong")
+    res = _login(client, "timedlock", "wrong")
+    data = res.get_json()
+    assert 0 < data["remaining_seconds"] <= LOCKOUT_DURATION_MINUTES * 60
+
+
+# ---------------------------------------------------------------------------
+# Admin unlock endpoint
+# ---------------------------------------------------------------------------
+
+def test_admin_can_unlock_locked_account(client, app, mock_db):
+    uid = _insert_user(mock_db, "targetlock")
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        increment_failed_attempts(str(uid))
+    assert get_lock_status(str(uid))["is_locked"] is True
+
+    token = _admin_token(app, mock_db)
+    res = client.post(
+        f"/api/admin/users/{uid}/unlock",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert get_lock_status(str(uid))["is_locked"] is False
+
+
+def test_admin_unlock_nonexistent_user_returns_404(client, app, mock_db):
+    token = _admin_token(app, mock_db)
+    res = client.post(
+        f"/api/admin/users/{ObjectId()}/unlock",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 404
+
+
+def test_non_admin_cannot_unlock(client, app, mock_db):
+    target_uid = _insert_user(mock_db, "targetuser2")
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        increment_failed_attempts(str(target_uid))
+
+    regular_uid = _insert_user(mock_db, "regularuser3")
+    with app.app_context():
+        from utils.jwt_auth import create_access_token
+        user_token = create_access_token(str(regular_uid), "user")
+
+    res = client.post(
+        f"/api/admin/users/{target_uid}/unlock",
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Account Lockout After Failed Login Attempts

Right now anyone can guess passwords on Beehive indefinitely there's
nothing stopping a brute-force attack. This PR fixes it.

After 5 consecutive wrong passwords, the account is locked for 15
minutes. Each failed attempt tells you how many tries you have left. It won't let you
in until the timer expires. A successful login clears the counter.

Admins can see which accounts are locked in the Users table and unlock them manually with one click if needed.
On the login page lockouts get their own distinct orange banner so
users know it's a lockout not just a wrong password.

### Changes
- `GET /api/auth/login` — lockout check, failure counter, reset on success
- `POST /api/admin/users/<id>/unlock` — admin override to clear a lockout
- Admin user list now includes `isLocked` and `failedAttempts` fields
- Login page shows a clear "Account Locked" message with time remaining
- 16 tests covering every path: countdown warnings, 429 on lockout,
  correct-password-while-locked, successful-login resets counter,
  admin unlock, 404/403 guards

### Test plan
- [x] Wrong password 4 times → each response shows attempts remaining
- [x] Wrong password 5th time → 429, orange banner on login page
- [x] Correct password while locked → still blocked with time remaining
- [x] Wait 15 min (or admin unlocks) → login works again
- [x] Successful login after 2 failures → counter resets, no lockout
- [x] `pytest tests/test_account_lockout.py` → 16 passed
