### PR TITLE
Feat : Enhance safety of delete actions

### DIFF
--- a/frontend/src/components/DeleteModal.tsx
+++ b/frontend/src/components/DeleteModal.tsx
@@ -1,0 +1,56 @@
+interface DeleteModalImage {
+  title?: string;
+  filename: string;
+}
+
+interface DeleteModalProps {
+  image: DeleteModalImage;
+  isDeleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const DeleteModal = ({ image, isDeleting, onClose, onConfirm }: DeleteModalProps) => {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg max-w-md w-full transition-colors duration-200">
+        <div className="p-6">
+          <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">Delete Image</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+            This action will permanently delete this image and cannot be undone.
+          </p>
+
+          <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg p-3 mb-6">
+            <p className="text-sm font-medium text-red-800 dark:text-red-200 truncate">
+              {image.title || image.filename}
+            </p>
+            <p className="text-xs text-red-700 dark:text-red-300 mt-1">
+              Associated files, including voice notes, will also be removed.
+            </p>
+          </div>
+
+          <div className="flex justify-end space-x-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isDeleting}
+              className="bg-gray-200 hover:bg-gray-300 disabled:opacity-60 disabled:cursor-not-allowed dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white font-semibold py-2 px-4 rounded-lg transition-colors duration-200"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={isDeleting}
+              className="bg-red-500 hover:bg-red-600 disabled:opacity-60 disabled:cursor-not-allowed text-white font-semibold py-2 px-4 rounded-lg transition-colors duration-200"
+            >
+              {isDeleting ? 'Deleting...' : 'Delete Permanently'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteModal;

--- a/frontend/src/components/DeleteModal.tsx
+++ b/frontend/src/components/DeleteModal.tsx
@@ -25,7 +25,7 @@ const DeleteModal = ({ image, isDeleting, onClose, onConfirm }: DeleteModalProps
               {image.title || image.filename}
             </p>
             <p className="text-xs text-red-700 dark:text-red-300 mt-1">
-              Associated files, including voice notes, will also be removed.
+              Associated voice notes, will also be removed.
             </p>
           </div>
 

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -508,7 +508,9 @@ const Gallery = () => {
   }, [restoreDeletedImage]);
 
   const handleConfirmDelete = async () => {
-    if (!deleteCandidate || isDeleting) {
+    if (!deleteCandidate) {
+      return;
+    }
       return;
     }
 

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -1476,7 +1476,7 @@ const Gallery = () => {
           <DeleteModal
             image={{ title: deleteCandidate.title, filename: deleteCandidate.filename }}
             isDeleting={isDeleting}
-            onClose={() => !isDeleting && setDeleteCandidate(null)}
+            onClose={() => setDeleteCandidate(null)}
             onConfirm={handleConfirmDelete}
           />
         )}

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -155,7 +155,7 @@ const Gallery = () => {
   const [sortOrder, setSortOrder] = useState(searchParams.get('sort_order') || 'desc');
   const [showFilters, setShowFilters] = useState(false);
   const [deleteCandidate, setDeleteCandidate] = useState<Upload | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteCandidate, setDeleteCandidate] = useState<Upload | null>(null);
   
   const [totalResults, setTotalResults] = useState(0);
   const [hasMore, setHasMore] = useState(false);

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -19,6 +19,7 @@ import {
 import toast from 'react-hot-toast';
 import { motion, AnimatePresence } from 'framer-motion';
 import { EmptyGalleryIcon } from '../components/ui/EmptyGalleryIcon';
+import DeleteModal from '../components/DeleteModal';
 
 interface Upload {
   id: string;
@@ -143,6 +144,8 @@ const Gallery = () => {
   const [sortBy, setSortBy] = useState(searchParams.get('sort_by') || 'date');
   const [sortOrder, setSortOrder] = useState(searchParams.get('sort_order') || 'desc');
   const [showFilters, setShowFilters] = useState(false);
+  const [deleteCandidate, setDeleteCandidate] = useState<Upload | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
   
   const [totalResults, setTotalResults] = useState(0);
   const [hasMore, setHasMore] = useState(false);
@@ -421,12 +424,13 @@ const Gallery = () => {
     }
   };
 
-  const handleDelete = async (id: string) => {
-    if (!window.confirm('Are you sure you want to delete this image?')) {
-      return;
-    }
+  const handleDeleteRequest = (image: Upload) => {
+    setDeleteCandidate(image);
+  };
 
+  const handleDelete = async (id: string) => {
     try {
+      setIsDeleting(true);
       // Optimistically update UI for immediate feedback
       const newImages = images.filter(img => img.id !== id);
       setImages(newImages);
@@ -459,7 +463,19 @@ const Gallery = () => {
       toast.error(error instanceof Error ? error.message : 'Failed to delete image');
       // On error, refetch to restore correct state
       fetchUploads(currentPage, false);
+    } finally {
+      setIsDeleting(false);
     }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deleteCandidate || isDeleting) {
+      return;
+    }
+
+    const targetId = deleteCandidate.id;
+    setDeleteCandidate(null);
+    await handleDelete(targetId);
   };
 
   const handleFileClick = (filename: string) => {
@@ -763,7 +779,7 @@ const Gallery = () => {
                               </span>
                             </motion.button>
                             <motion.button
-                              onClick={() => handleDelete(filteredImages[currentRollingIndex].id)}
+                              onClick={() => handleDeleteRequest(filteredImages[currentRollingIndex])}
                               className="p-2.5 rounded-full bg-white/20 hover:bg-white/30 text-white transition-all duration-200 group"
                               whileHover={{ scale: 1.1 }}
                               whileTap={{ scale: 0.95 }}
@@ -1164,7 +1180,7 @@ const Gallery = () => {
                               <PencilIcon className="h-4 w-4" />
                             </motion.button>
                             <motion.button
-                              onClick={() => handleDelete(image.id)}
+                              onClick={() => handleDeleteRequest(image)}
                               className="p-1.5 text-gray-600 hover:text-red-500 dark:text-gray-400 transition-colors duration-200"
                               title="Delete"
                               whileHover={{ scale: 1.1 }}
@@ -1357,6 +1373,15 @@ const Gallery = () => {
             image={editingImage}
             onClose={() => setEditingImage(null)}
             onSave={handleSave}
+          />
+        )}
+
+        {deleteCandidate && (
+          <DeleteModal
+            image={deleteCandidate}
+            isDeleting={isDeleting}
+            onClose={() => !isDeleting && setDeleteCandidate(null)}
+            onConfirm={handleConfirmDelete}
           />
         )}
 

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -1474,7 +1474,7 @@ const Gallery = () => {
 
         {deleteCandidate && (
           <DeleteModal
-            image={{ title: deleteCandidate.title, filename: deleteCandidate.filename }}
+            image={deleteCandidate}
             isDeleting={isDeleting}
             onClose={() => setDeleteCandidate(null)}
             onConfirm={handleConfirmDelete}

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -16,10 +16,12 @@ import {
   MagnifyingGlassIcon,
   FunnelIcon,
 } from '@heroicons/react/24/outline';
-import toast from 'react-hot-toast';
+import toast, { type Toast } from 'react-hot-toast';
 import { motion, AnimatePresence } from 'framer-motion';
 import { EmptyGalleryIcon } from '../components/ui/EmptyGalleryIcon';
 import DeleteModal from '../components/DeleteModal';
+
+const DELETE_UNDO_WINDOW_MS = 5000;
 
 interface Upload {
   id: string;
@@ -35,6 +37,14 @@ interface EditModalProps {
   image: Upload;
   onClose: () => void;
   onSave: (id: string, title: string, description: string, sentiment: string) => void;
+}
+
+interface PendingDeletion {
+  image: Upload;
+  originalIndex: number;
+  pageToRefresh: number;
+  timeoutId: ReturnType<typeof setTimeout>;
+  toastId: string;
 }
 
 const EditModal = ({ image, onClose, onSave }: EditModalProps) => {
@@ -152,6 +162,7 @@ const Gallery = () => {
   
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const pendingDeletionRef = useRef<Map<string, PendingDeletion>>(new Map());
 
   // Auto-switch from relevance to date when search query is cleared
   useEffect(() => {
@@ -307,9 +318,9 @@ const Gallery = () => {
       setTotalPages(Math.ceil((data.total || 0) / pageSize));
       setTotalCount(data.total || 0);
       setCurrentPage(page);
-    } catch (error: any) {
+    } catch (error: unknown) {
       // Ignore abort errors
-      if (error.name === 'AbortError') {
+      if (error instanceof Error && error.name === 'AbortError') {
         return;
       }
       console.error('Error fetching uploads:', error);
@@ -428,54 +439,124 @@ const Gallery = () => {
     setDeleteCandidate(image);
   };
 
-  const handleDelete = async (id: string) => {
+  const restoreDeletedImage = useCallback((image: Upload, originalIndex: number) => {
+    setImages((prev) => {
+      if (prev.some((item) => item.id === image.id)) {
+        return prev;
+      }
+      const next = [...prev];
+      const safeIndex = Math.min(Math.max(originalIndex, 0), next.length);
+      next.splice(safeIndex, 0, image);
+      return next;
+    });
+    setTotalCount((prevCount) => prevCount + 1);
+    setTotalResults((prevTotal) => prevTotal + 1);
+  }, []);
+
+  const finalizeDelete = useCallback(async (id: string) => {
+    const pending = pendingDeletionRef.current.get(id);
+    if (!pending) {
+      return;
+    }
+
     try {
       setIsDeleting(true);
-      // Optimistically update UI for immediate feedback
-      const newImages = images.filter(img => img.id !== id);
-      setImages(newImages);
-      setTotalCount(prevCount => prevCount - 1);
 
-      // Perform the deletion
       const response = await authenticatedFetch(`/delete/${id}`, { method: 'DELETE' });
       if (!response.ok) {
         let errorMsg = 'Failed to delete image';
         try {
           const errorData = await response.json();
           errorMsg = errorData.error || errorMsg;
-        } catch (e) {
+        } catch {
           // Response was not JSON, stick with the default message.
         }
         throw new Error(errorMsg);
       }
-      // If the last item on a page (other than the first) was deleted, go to the previous page
-      if (newImages.length === 0 && currentPage > 1) {
-        fetchUploads(currentPage - 1, false);
-      } else {
-        // Refetch the current page to pull a new item from the next page if available
-        // and to ensure pagination metadata is correct
-        fetchUploads(currentPage, false);
-      }
+
+      pendingDeletionRef.current.delete(id);
+      toast.dismiss(pending.toastId);
+      fetchUploads(pending.pageToRefresh, false);
 
       toast.success('Image deleted successfully!');
     } catch (error) {
+      pendingDeletionRef.current.delete(id);
       console.error('Error deleting image:', error);
+      restoreDeletedImage(pending.image, pending.originalIndex);
+      toast.dismiss(pending.toastId);
       toast.error(error instanceof Error ? error.message : 'Failed to delete image');
       // On error, refetch to restore correct state
-      fetchUploads(currentPage, false);
+      fetchUploads(pending.pageToRefresh, false);
     } finally {
       setIsDeleting(false);
     }
-  };
+  }, [authenticatedFetch, fetchUploads, restoreDeletedImage]);
+
+  const handleUndoDelete = useCallback((id: string) => {
+    const pending = pendingDeletionRef.current.get(id);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeoutId);
+    pendingDeletionRef.current.delete(id);
+    toast.dismiss(pending.toastId);
+    restoreDeletedImage(pending.image, pending.originalIndex);
+    toast.success('Deletion undone');
+  }, [restoreDeletedImage]);
 
   const handleConfirmDelete = async () => {
     if (!deleteCandidate || isDeleting) {
       return;
     }
 
-    const targetId = deleteCandidate.id;
+    const imageToDelete = deleteCandidate;
+    const targetId = imageToDelete.id;
+    const originalIndex = images.findIndex((img) => img.id === targetId);
+    const remainingImagesCount = images.length - 1;
+    const pageToRefresh = remainingImagesCount === 0 && currentPage > 1 ? currentPage - 1 : currentPage;
+
     setDeleteCandidate(null);
-    await handleDelete(targetId);
+    setImages((prev) => prev.filter((img) => img.id !== targetId));
+    setTotalCount((prevCount) => Math.max(0, prevCount - 1));
+    setTotalResults((prevTotal) => Math.max(0, prevTotal - 1));
+
+    const toastId = toast.custom(
+      (t: Toast) => (
+        <div
+          className={`w-[calc(100vw-2rem)] max-w-xs sm:max-w-md bg-red-50 dark:bg-red-950/90 border border-red-300 dark:border-red-700 shadow-2xl rounded-xl pointer-events-auto px-4 py-3 flex items-center justify-between gap-3 ${
+            t.visible ? 'animate-enter' : 'animate-leave'
+          }`}
+        >
+          <p className="text-sm font-medium text-red-900 dark:text-red-100">
+            Image deleted.  
+          </p>
+          <button
+            type="button"
+            onClick={() => handleUndoDelete(targetId)}
+            className="inline-flex items-center rounded-md bg-red-700 hover:bg-red-800 dark:bg-red-500 dark:hover:bg-red-400 px-3 py-1.5 text-sm font-semibold text-white transition-colors duration-200"
+          >
+            Undo
+          </button>
+        </div>
+      ),
+      {
+        duration: DELETE_UNDO_WINDOW_MS,
+        position: 'top-center',
+      }
+    );
+
+    const timeoutId = setTimeout(() => {
+      void finalizeDelete(targetId);
+    }, DELETE_UNDO_WINDOW_MS);
+
+    pendingDeletionRef.current.set(targetId, {
+      image: imageToDelete,
+      originalIndex,
+      pageToRefresh,
+      timeoutId,
+      toastId,
+    });
   };
 
   const handleFileClick = (filename: string) => {
@@ -563,8 +644,8 @@ const Gallery = () => {
           }
         });
       }
-    } catch (error: any) {
-      if (error.name === 'AbortError') {
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'AbortError') {
         return;
       }
       console.error('Error fetching audio:', error);
@@ -578,6 +659,17 @@ const Gallery = () => {
       cleanupAudio();
     };
   }, [cleanupAudio]);
+
+  useEffect(() => {
+    const pendingDeletions = pendingDeletionRef.current;
+    return () => {
+      pendingDeletions.forEach((pending) => {
+        clearTimeout(pending.timeoutId);
+        toast.dismiss(pending.toastId);
+      });
+      pendingDeletions.clear();
+    };
+  }, []);
 
   const renderFilePreview = () => {
     if (!selectedFile) return null;

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -1378,7 +1378,7 @@ const Gallery = () => {
 
         {deleteCandidate && (
           <DeleteModal
-            image={deleteCandidate}
+            image={{ title: deleteCandidate.title, filename: deleteCandidate.filename }}
             isDeleting={isDeleting}
             onClose={() => !isDeleting && setDeleteCandidate(null)}
             onConfirm={handleConfirmDelete}

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -476,7 +476,9 @@ const Gallery = () => {
 
       pendingDeletionRef.current.delete(id);
       toast.dismiss(pending.toastId);
-      fetchUploads(pending.pageToRefresh, false);
+      if (currentPage === pending.pageToRefresh) {
+        fetchUploads(pending.pageToRefresh, false);
+      }
 
       toast.success('Image deleted successfully!');
     } catch (error) {


### PR DESCRIPTION
### Summary

- This PR replaces the browser-native delete confirmation with a reusable in-app modal to provide a safer and more contextual deletion experience for sensitive healthcare content.

---

### Before 

<img width="957" height="542" alt="image" src="https://github.com/user-attachments/assets/a0f76434-c881-428e-baba-6b080a3331e3" />


### After

<img width="950" height="540" alt="image" src="https://github.com/user-attachments/assets/d7937ef5-c51d-45f8-a124-413faaf79dbe" />

### Undo 

<img width="347" height="54" alt="image" src="https://github.com/user-attachments/assets/ff405715-c0b0-4c94-bc13-376acd988465" />


---
### Problem
Browser-native confirmation dialogs:
- Lack contextual information about the item being deleted
- Provide a poor and inconsistent user experience
### Solution
- Introduced a reusable `DeleteModal` component
- Replaced all native `confirm()` usage in the Gallery with the custom modal
- Centralized deletion UX into a consistent, extensible pattern

### Changes

### Undo feat

- Added Undo delete behavior (5-second grace period)
- Added cleanup for pending toasts on unmount
- User gets an Undo toast; clicking Undo restores the item and cancels server delete



### Added
- `DeleteModal.tsx`
  - Reusable modal for destructive action confirmation
  - Displays dynamic item name (title or filename)

### Updated
- `Gallery.tsx`
  - Integrated `DeleteModal`
  - Removed native confirmation logic



**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
