### PR TITLE
fix: IDOR and media exposure via static uploads folder #603

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,7 +164,7 @@ dmypy.json
 cython_debug/
 
 # Ignore the uploads folder where user files are stored
-static/uploads/
+uploads/
 
 client_secret.json
 user_info.json

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project aims to analyze behavioral health and complement healthcare practic
 - **User Authentication**: Google OAuth2
 - **Local Authentication**: JWT-based auth with optional Google OAuth for admin
 - **Database**: MongoDB
-- **Storage**: Local filesystem for media uploads in `static/uploads/` with PDF thumbnails in `static/uploads/thumbnails/`
+- **Storage**: Local filesystem for media uploads in `uploads/` with PDF thumbnails in `uploads/thumbnails/`
   
 ## Workflow
 ```mermaid

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from dotenv import load_dotenv
+from database import userdatahandler
 load_dotenv()
 
 import base64
@@ -449,6 +450,14 @@ def upload_images():
 
                 # Always safe to call now
                 time_created = datetime.datetime.now()
+                
+                # Generate pdf thumbnail
+                thumbnail_filename = None
+                if unique_filename.lower().endswith(".pdf"):
+                    name, _ = os.path.splitext(unique_filename)
+                    thumbnail_filename = f"{name}.jpg"
+                    generate_pdf_thumbnail(filepath, unique_filename)
+                
                 save_image(
                     user_id,
                     unique_filename,
@@ -457,14 +466,11 @@ def upload_images():
                     time_created,
                     audio_filename,
                     sentiment,
+                    thumbnail_filename,
                 )
                 save_notification(
                     user_id, username, unique_filename, title, time_created, sentiment
                 )
-
-                # Generate PDF thumbnail if applicable
-                if unique_filename.lower().endswith(".pdf"):
-                    generate_pdf_thumbnail(filepath, unique_filename)
 
         return jsonify({"message": "Upload successful"}), 200
 
@@ -691,15 +697,13 @@ def serve_audio(filename):
 def serve_protected_file(filename):
     # Serve files strictly to their owners or admins to prevent IDOR
     try:
-        db_filename = filename
         if filename.startswith("thumbnails/"):
-            db_filename = filename.replace("thumbnails/", "")
-            db_filename = db_filename.rsplit('.', 1)[0] + '.pdf'
-        
-        image = get_image_by_filename(db_filename)
+            image = userdatahandler.get_image_by_thumbnail(filename)
+        else:
+            image = userdatahandler.get_image_by_filename(filename)
         
         if not image:
-            return jsonify({"error": "File not found or unassociated"}), 404
+            return jsonify({"error": "File not found"}), 404
 
         current_user_id = request.current_user.get("id")
         current_user_role = request.current_user.get("role", "user")

--- a/app.py
+++ b/app.py
@@ -48,6 +48,7 @@ from database.userdatahandler import (
     save_image,
     save_notification,
     update_image,
+    get_image_by_filename
 )
 
 from utils.jwt_auth import require_auth,require_admin_role 
@@ -153,8 +154,6 @@ if (
     raise ValueError(
         "CRITICAL: Set a secure FLASK_SECRET_KEY (at least 32 characters) in the environment!"
     )
-app.config["UPLOAD_FOLDER"] = "static/uploads"
-app.config["PDF_THUMBNAIL_FOLDER"] = "static/uploads/thumbnails/"
 app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024
 if os.getenv("FLASK_ENV") == "development":
     os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
@@ -687,6 +686,35 @@ def serve_audio(filename):
         logging.error(f"Error serving audio file '{filename}': {str(e)}")
         return jsonify({"error": "Failed to serve audio file"}), 500
 
+@app.route("/api/files/<path:filename>")
+@require_auth
+def serve_protected_file(filename):
+    # Serve files strictly to their owners or admins to prevent IDOR
+    try:
+        db_filename = filename
+        if filename.startswith("thumbnails/"):
+            db_filename = filename.replace("thumbnails/", "")
+            db_filename = db_filename.rsplit('.', 1)[0] + '.pdf'
+        
+        image = get_image_by_filename(db_filename)
+        
+        if not image:
+            return jsonify({"error": "File not found or unassociated"}), 404
+
+        current_user_id = request.current_user.get("id")
+        current_user_role = request.current_user.get("role", "user")
+        
+        is_admin = current_user_role == "admin"
+        is_owner = check_owner(current_user_id, image.get("user_id"))
+
+        if not (is_admin or is_owner):
+            return jsonify({"error": "Unauthorized: You do not have permission to view this file."}), 403
+
+        return send_from_directory(app.config["UPLOAD_FOLDER"], filename)
+
+    except Exception as e:
+        app_logger.error(f"Error serving protected file '{filename}': {str(e)}")
+        return jsonify({"error": "Failed to serve file"}), 500
 
 # Delete images uploaded by the user
 @app.route("/delete/<image_id>", methods=["DELETE"])

--- a/config.py
+++ b/config.py
@@ -12,8 +12,8 @@ class Config:
     
     # Flask Configuration
     SECRET_KEY = os.getenv('FLASK_SECRET_KEY')
-    UPLOAD_FOLDER = 'static/uploads'
-    PDF_THUMBNAIL_FOLDER = 'static/uploads/thumbnails/'
+    UPLOAD_FOLDER = 'uploads'
+    PDF_THUMBNAIL_FOLDER = 'uploads/thumbnails/'
     
     # Database Configuration
     MONGODB_URI = os.getenv('MONGODB_URI')

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -58,7 +58,7 @@ def get_user_by_id(user_id: str):
 
 
 # Save image to MongoDB
-def save_image(id, filename, title, description, time_created, audio_filename=None, sentiment=None):
+def save_image(id, filename, title, description, time_created, audio_filename=None, sentiment=None, thumbnail_filename=None):
     try:
         normalized_user_id = ObjectId(id)
     except (TypeError, ValueError):
@@ -72,10 +72,31 @@ def save_image(id, filename, title, description, time_created, audio_filename=No
         'description': description,
         'created_at': time_created,
         'audio_filename': audio_filename,
-        'sentiment': sentiment
+        'sentiment': sentiment,
+        'thumbnail_filename': thumbnail_filename
     }
     beehive_image_collection.insert_one(image)
     update_last_seen(id)
+
+def get_image_by_thumbnail(thumbnail_filename):
+    # Extract the filename
+    if thumbnail_filename.startswith("thumbnails/"):
+        thumbnail_filename = thumbnail_filename.replace("thumbnails/", "")
+
+    # Case insensitive matching for thumbnail filename
+    image = beehive_image_collection.find_one({
+        'thumbnail_filename': re.compile(f'^{re.escape(thumbnail_filename)}$', re.IGNORECASE)
+    })
+
+    if image:
+        return image
+
+    # map to the original pdf filename in case if thumbnail not found
+    base_name = re.sub(r'\.[^.]+$', '', thumbnail_filename)
+    return beehive_image_collection.find_one({
+        'filename': re.compile(f'^{re.escape(base_name)}\.pdf$', re.IGNORECASE)
+    })
+    
 # Count all images from MongoDB
 def total_images():
     return beehive_image_collection.count_documents({})

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -762,4 +762,4 @@ def get_user_analytics():
 
 # Get image record by its filename for ownership verification
 def get_image_by_filename(filename):
-    return beehive_image_collection.find_one({'filename': filename})
+    return beehive_image_collection.find_one({'filename': re.compile(f'^{re.escape(filename)}$', re.IGNORECASE)})

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -92,7 +92,7 @@ def get_image_by_thumbnail(thumbnail_filename):
         return image
 
     # map to the original pdf filename in case if thumbnail not found
-    base_name = re.sub(r'\.[^.]+$', '', thumbnail_filename)
+    base_name = thumbnail_filename.rsplit('.', 1)[0]
     return beehive_image_collection.find_one({
         'filename': re.compile(f'^{re.escape(base_name)}\.pdf$', re.IGNORECASE)
     })

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -759,3 +759,7 @@ def get_user_analytics():
         logger.error(f"Error getting user analytics: {e}")
         return None
     
+
+# Get image record by its filename for ownership verification
+def get_image_by_filename(filename):
+    return beehive_image_collection.find_one({'filename': filename})

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,8 +28,8 @@ Base URL (dev): `http://127.0.0.1:5000`
   - 500: `{ error: "Error uploading file: ..." }`
 
 Side effects:
-- Saves files to `static/uploads/`.
-- Generates PDF thumbnail for `.pdf` as `.jpg` in `static/uploads/thumbnails/`.
+- Saves files to `uploads/`.
+- Generates PDF thumbnail for `.pdf` as `.jpg` in `uploads/thumbnails/`.
 - Inserts `image` record and admin `notification` in MongoDB.
 
 ---
@@ -117,7 +117,7 @@ Side effects:
 ### Static Media
 
 #### GET `/audio/{filename}`
-- Serves audio file from `static/uploads/`.
+- Serves audio file from `uploads/`.
 
 ---
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -6,10 +6,10 @@
 ### 2) User Upload Media
 1. User submits form to `POST /api/user/upload` with files, title, description, optional `audioData` and `sentiment`.
 2. Backend validates inputs and allowed extensions.
-3. Files saved to `static/uploads/`; optional audio decoded from base64 and saved.
+3. Files saved to `uploads/`; optional audio decoded from base64 and saved.
 4. MongoDB `images` document inserted.
 5. Admin `notifications` document inserted.
-6. If PDF, generate thumbnail to `static/uploads/thumbnails/`.
+6. If PDF, generate thumbnail to `uploads/thumbnails/`.
 
 ### 3) Edit Media
 1. Owner hits `PATCH /edit/{image_id}` with new `title`, `description`, optional `sentiment`.
@@ -17,7 +17,7 @@
 
 ### 4) Delete Media
 1. Owner hits `DELETE /delete/{image_id}`.
-2. Backend deletes file from `static/uploads/`, removes audio and PDF thumbnail if exist.
+2. Backend deletes file from `uploads/`, removes audio and PDF thumbnail if exist.
 3. Deletes MongoDB image document.
 
 ### 5) View User Uploads

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -52,7 +52,8 @@ export const ProtectedMedia = ({ filename, isPdf = false, className = '', alt = 
         const response = await fetch(apiUrl(`/api/files/${filename}`), {
           headers: {
             'Authorization': `Bearer ${getToken()}`
-          }
+          },
+          credentials: 'include'
         });
 
         if (!response.ok) throw new Error('Failed to load media');

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -103,7 +103,8 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
     const fetchAudio = async () => {
       try {
         const response = await fetch(apiUrl(`/api/audio/${filename}`), {
-          headers: { 'Authorization': `Bearer ${getToken()}` }
+          headers: { 'Authorization': `Bearer ${getToken()}` },
+          credentials: 'include'
         });
 
         if (response.ok) {

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -49,10 +49,11 @@ export const ProtectedMedia = ({ filename, isPdf = false, className = '', alt = 
 
     const fetchMedia = async () => {
       try {
-        const response = await fetch(apiUrl(`/api/files/${filename}`), {
-          headers: {
-            'Authorization': `Bearer ${getToken()}`
-          },
+        const token = getToken();
+        const response = await fetch(encodeURI(apiUrl(`/api/files/${filename}`)), {
+          headers: token ? {
+            'Authorization': `Bearer ${token}`
+          } : {},
           credentials: 'include'
         });
 
@@ -102,8 +103,9 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
 
     const fetchAudio = async () => {
       try {
-        const response = await fetch(apiUrl(`/api/audio/${filename}`), {
-          headers: { 'Authorization': `Bearer ${getToken()}` },
+        const token = getToken();
+        const response = await fetch(encodeURI(apiUrl(`/api/audio/${filename}`)), {
+          headers: token ? { 'Authorization': `Bearer ${token}` } : {},
           credentials: 'include'
         });
 

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -1,5 +1,22 @@
 import { Navigate, Outlet } from "react-router-dom";
 import { isAuthenticated, getUserRole } from "../utils/auth";
+import { useState, useEffect } from 'react';
+import { apiUrl } from '../utils/api';
+import { getToken } from '../utils/auth';
+
+interface ProtectedMediaProps {
+  filename: string;
+  isPdf?: boolean;
+  className?: string;
+  alt?: string;
+}
+
+interface ProtectedAudioProps {
+  filename: string;
+  className?: string;
+  onEnded?: () => void;
+}
+
 
 export const AdminRoute = () => {
   if (!isAuthenticated()) {
@@ -21,4 +38,99 @@ export const UserRoute = () => {
   }
 
   return <Outlet />;
+};
+
+export const ProtectedMedia = ({ filename, isPdf = false, className = '', alt = 'Secure media' }: ProtectedMediaProps) => {
+  const [src, setSrc] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let objectUrl: string | null = null;
+
+    const fetchMedia = async () => {
+      try {
+        const response = await fetch(apiUrl(`/api/files/${filename}`), {
+          headers: {
+            'Authorization': `Bearer ${getToken()}`
+          }
+        });
+
+        if (!response.ok) throw new Error('Failed to load media');
+
+        const blob = await response.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      } catch (err) {
+        console.error("Error loading protected media:", err);
+        setError(true);
+      }
+    };
+
+    if (filename) {
+      fetchMedia();
+    }
+
+    // memory cleanup to prevent browser memory leaks
+    return () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [filename]);
+
+  if (error) {
+    return <div className={`flex items-center justify-center bg-gray-200 dark:bg-gray-700 text-gray-500 ${className}`}>Failed to load</div>;
+  }
+
+  if (!src) {
+    return <div className={`animate-pulse bg-gray-200 dark:bg-gray-700 ${className}`}></div>;
+  }
+
+  if (isPdf) {
+    return <iframe src={src} className={className} title={alt} />;
+  }
+
+  return <img src={src} alt={alt} className={className} />;
+};
+
+export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedAudioProps) => {
+  const [src, setSrc] = useState<string | null>(null);
+
+  useEffect(() => {
+    let objectUrl: string | null = null;
+
+    const fetchAudio = async () => {
+      try {
+        const response = await fetch(apiUrl(`/api/audio/${filename}`), {
+          headers: { 'Authorization': `Bearer ${getToken()}` }
+        });
+
+        if (response.ok) {
+          const blob = await response.blob();
+          objectUrl = URL.createObjectURL(blob);
+          setSrc(objectUrl);
+        }
+      } catch (error) {
+        console.error("Failed to load secure audio", error);
+      }
+    };
+
+    fetchAudio();
+
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [filename]);
+
+  if (!src) return <div className="text-sm text-gray-500 p-2 animate-pulse">Loading secure audio...</div>;
+
+  return (
+    <audio
+      controls
+      src={src}
+      className={className}
+      onEnded={onEnded}
+      autoPlay
+    />
+  );
 };

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -601,7 +601,8 @@ const handleDownload = async (filename: string, type: 'file' | 'audio' = 'file')
 
   const getThumbnailPath = (filename: string) => {
     if (filename.toLowerCase().endsWith('.pdf')) {
-      return `thumbnails/${filename.replace('.pdf', '.jpg')}`;
+      const baseName = filename.replace(/\.pdf$/i, '');
+      return `thumbnails/${baseName}.jpg`;
     }
     return filename;
   };

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -19,6 +19,7 @@ import {
 import toast from 'react-hot-toast';
 import { motion, AnimatePresence } from 'framer-motion';
 import { EmptyGalleryIcon } from '../components/ui/EmptyGalleryIcon';
+import { ProtectedMedia } from '../components/ProtectedRoutes';
 
 interface Upload {
   id: string;
@@ -134,7 +135,7 @@ const Gallery = () => {
   const [totalCount, setTotalCount] = useState(0);
   const [pageSize, setPageSize] = useState(12);
   const observerTarget = useRef<HTMLDivElement | null>(null);
-  
+
   // Search and filter states
   const [searchQuery, setSearchQuery] = useState(searchParams.get('q') || '');
   const [sentiment, setSentiment] = useState(searchParams.get('sentiment') || '');
@@ -143,10 +144,10 @@ const Gallery = () => {
   const [sortBy, setSortBy] = useState(searchParams.get('sort_by') || 'date');
   const [sortOrder, setSortOrder] = useState(searchParams.get('sort_order') || 'desc');
   const [showFilters, setShowFilters] = useState(false);
-  
+
   const [totalResults, setTotalResults] = useState(0);
   const [hasMore, setHasMore] = useState(false);
-  
+
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -161,20 +162,20 @@ const Gallery = () => {
   const generatePageNumbers = (currentPage: number, totalResults: number, pageSize: number) => {
     const totalPageCount = Math.ceil(totalResults / pageSize);
     const pages: number[] = [];
-    
+
     // Always show first page
     pages.push(1);
-    
+
     // Show pages around current page
     for (let i = Math.max(2, currentPage - 1); i <= Math.min(totalPageCount - 1, currentPage + 1); i++) {
       pages.push(i);
     }
-    
+
     // Always show last page
     if (totalPageCount > 1) {
       pages.push(totalPageCount);
     }
-    
+
     // Remove duplicates and sort
     return Array.from(new Set(pages)).sort((a, b) => a - b);
   };
@@ -189,7 +190,7 @@ const Gallery = () => {
     if (sortBy !== 'date') params.sort_by = sortBy;
     if (sortOrder !== 'desc') params.sort_order = sortOrder;
     if (currentPage > 1) params.page = currentPage.toString();
-    
+
     setSearchParams(params, { replace: true });
   }, [searchQuery, sentiment, fromDate, toDate, sortBy, sortOrder, currentPage, setSearchParams]);
 
@@ -227,7 +228,7 @@ const Gallery = () => {
       audioAbortController.current.abort();
       audioAbortController.current = null;
     }
-    
+
     if (audioRef.current) {
       audioRef.current.pause();
       audioRef.current.currentTime = 0;
@@ -240,59 +241,59 @@ const Gallery = () => {
       }
       return null;
     });
-    
+
     setCurrentAudio(null);
     setAudioLoading(false);
   }, []);
 
   // Fetch uploads with search and filters
   const fetchUploads = useCallback(async (page: number = 1, append: boolean = false) => {
-    
+
     // Cancel previous request
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
-    
+
     // Create new AbortController for this request
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
-    
+
     try {
       if (page === 1) {
         setLoading(true);
       } else {
         setLoadingMore(true);
       }
-      
+
       // Always use offset/limit pagination
       const offset = (page - 1) * pageSize;
       const params = new URLSearchParams({
         limit: pageSize.toString(),
         offset: offset.toString(),
       });
-      
+
       if (searchQuery.trim()) params.append('q', searchQuery.trim());
       if (sentiment) params.append('sentiment', sentiment);
       if (fromDate) params.append('from', fromDate);
       if (toDate) params.append('to', toDate);
       if (sortBy) params.append('sort_by', sortBy);
       if (sortOrder) params.append('sort_order', sortOrder);
-      
+
       const response = await authenticatedFetch(`/api/user/user_uploads?${params}`, {
         method: 'GET',
         mode: 'cors',
         signal: abortController.signal
       });
-      
+
       if (!response.ok) {
         throw new Error('Failed to fetch uploads');
       }
-      
+
       const data = await response.json();
       if (data.error) {
         throw new Error(data.error);
       }
-      
+
       // Handle unified response format
       if (append) {
         setImages(prev => [...prev, ...(data.images || [])]);
@@ -323,11 +324,11 @@ const Gallery = () => {
   //Initial fetch and search trigger with debouncing
   useEffect(() => {
     setCurrentPage(1);
-    
+
     searchTimeoutRef.current = setTimeout(() => {
       fetchUploads(1, false);
     }, 300);
-    
+
     return () => {
       if (searchTimeoutRef.current) {
         clearTimeout(searchTimeoutRef.current);
@@ -378,7 +379,7 @@ const Gallery = () => {
       }
     };
   }, [fetchUploads, currentPage, totalPages, hasMore, loadingMore, loading, viewMode, searchQuery, sentiment, fromDate, toDate, sortBy, sortOrder]);
-  
+
   const handleClearFilters = () => {
     setSearchQuery('');
     setSentiment('');
@@ -472,10 +473,33 @@ const Gallery = () => {
     setSelectedFile(null);
   };
 
-  const handleDownload = (filename: string) => {
-    const url = apiUrl(`/static/uploads/${filename}`);
-    window.open(url, '_blank');
-    toast.success('File opened in new window!');
+const handleDownload = async (filename: string, type: 'file' | 'audio' = 'file') => {
+    try {
+      // Audio uses /api/audio/, images use /api/files/
+      const endpoint = type === 'audio' ? `/api/audio/${filename}` : `/api/files/${filename}`;
+      
+      const response = await fetch(apiUrl(endpoint), {
+        headers: { 'Authorization': `Bearer ${getToken()}` }
+      });
+      
+      if (!response.ok) throw new Error('Download failed');
+      
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.style.display = 'none';
+      a.href = url;
+      a.download = filename; // download instead of opening in tab
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+      
+      toast.success(`${type === 'file' ? 'File' : 'Audio'} downloaded successfully!`);
+    } catch (error) {
+      console.error('Download error:', error);
+      toast.error('Failed to download file.');
+    }
   };
 
   const handleAudioClick = async (audioFilename: string) => {
@@ -565,36 +589,23 @@ const Gallery = () => {
 
   const renderFilePreview = () => {
     if (!selectedFile) return null;
-
-    const fileUrl = apiUrl(`/static/uploads/${selectedFile}`);
     const isPDF = selectedFile.toLowerCase().endsWith('.pdf');
 
-    if (isPDF) {
-      return (
-        <iframe
-          src={fileUrl}
-          className="w-full h-[80vh]"
-          title="PDF Preview"
-        />
-      );
-    }
-
     return (
-      <img
-        src={fileUrl}
-        alt="Uploaded file"
-        className="max-w-full h-auto mx-auto"
+      <ProtectedMedia
+        filename={selectedFile}
+        isPdf={isPDF}
+        className={isPDF ? "w-full h-[80vh]" : "max-w-full h-auto mx-auto"}
+        alt="File preview"
       />
     );
   };
 
-  const getThumbnailUrl = (filename: string) => {
+  const getThumbnailPath = (filename: string) => {
     if (filename.toLowerCase().endsWith('.pdf')) {
-      // For PDFs, use the thumbnail
-      return apiUrl(`/static/uploads/thumbnails/${filename.replace('.pdf', '.jpg')}`);
+      return `thumbnails/${filename.replace('.pdf', '.jpg')}`;
     }
-    // For images, use the original file
-    return apiUrl(`/static/uploads/${filename}`);
+    return filename;
   };
 
   const getSentimentColor = (sentiment?: string) => {
@@ -697,10 +708,10 @@ const Gallery = () => {
               >
                 <div className="relative w-full h-full max-w-5xl mx-auto">
                   <div className="relative w-full h-full rounded-2xl overflow-hidden shadow-2xl">
-                    <img
-                      src={getThumbnailUrl(filteredImages[currentRollingIndex].filename)}
+                    <ProtectedMedia
+                      filename={getThumbnailPath(filteredImages[currentRollingIndex].filename)}
                       alt={filteredImages[currentRollingIndex].title}
-                      className="w-full h-full object-contain bg-gray-100 dark:bg-gray-800"
+                      className="w-full h-full object-cover transition-transform duration-200"
                     />
 
                     {/* Enhanced Overlay */}
@@ -866,33 +877,30 @@ const Gallery = () => {
               <div className="flex rounded-lg bg-white dark:bg-gray-800 shadow-sm p-1">
                 <button
                   onClick={() => setViewMode('grid')}
-                  className={`p-2 rounded-md transition-colors duration-200 ${
-                    viewMode === 'grid'
-                      ? 'bg-yellow-400 text-black'
-                      : 'text-gray-600 hover:text-yellow-400 dark:text-gray-400'
-                  }`}
+                  className={`p-2 rounded-md transition-colors duration-200 ${viewMode === 'grid'
+                    ? 'bg-yellow-400 text-black'
+                    : 'text-gray-600 hover:text-yellow-400 dark:text-gray-400'
+                    }`}
                   title="Grid View"
                 >
                   <Squares2X2Icon className="h-5 w-5" />
                 </button>
                 <button
                   onClick={() => setViewMode('list')}
-                  className={`p-2 rounded-md transition-colors duration-200 ${
-                    viewMode === 'list'
-                      ? 'bg-yellow-400 text-black'
-                      : 'text-gray-600 hover:text-yellow-400 dark:text-gray-400'
-                  }`}
+                  className={`p-2 rounded-md transition-colors duration-200 ${viewMode === 'list'
+                    ? 'bg-yellow-400 text-black'
+                    : 'text-gray-600 hover:text-yellow-400 dark:text-gray-400'
+                    }`}
                   title="List View"
                 >
                   <ListBulletIcon className="h-5 w-5" />
                 </button>
                 <button
                   onClick={() => setViewMode('rolling')}
-                  className={`p-2 rounded-md transition-colors duration-200 ${
-                    viewMode === 'rolling'
-                      ? 'bg-yellow-400 text-black'
-                      : 'text-gray-600 hover:text-yellow-400 dark:text-gray-400'
-                  }`}
+                  className={`p-2 rounded-md transition-colors duration-200 ${viewMode === 'rolling'
+                    ? 'bg-yellow-400 text-black'
+                    : 'text-gray-600 hover:text-yellow-400 dark:text-gray-400'
+                    }`}
                   title="Rolling View"
                 >
                   <ChevronRightIcon className="h-5 w-5" />
@@ -1111,10 +1119,10 @@ const Gallery = () => {
                       whileHover={{ scale: 1.05 }}
                       transition={{ duration: 0.2 }}
                     >
-                      <img
-                        src={getThumbnailUrl(image.filename)}
+                      <ProtectedMedia
+                        filename={getThumbnailPath(image.filename)}
                         alt={image.title}
-                        className={`w-full h-full object-cover transition-transform duration-200`}
+                        className="w-full h-full object-cover transition-transform duration-200"
                       />
                       {image.sentiment && (
                         <motion.span
@@ -1195,13 +1203,12 @@ const Gallery = () => {
                           <motion.button
                             onClick={() => handleAudioClick(image.audio_filename!)}
                             disabled={audioLoading && currentAudio !== image.audio_filename}
-                            className={`p-1.5 rounded-full transition-colors duration-200 ${
-                              currentAudio === image.audio_filename
-                                ? 'bg-yellow-400 text-black'
-                                : audioLoading
+                            className={`p-1.5 rounded-full transition-colors duration-200 ${currentAudio === image.audio_filename
+                              ? 'bg-yellow-400 text-black'
+                              : audioLoading
                                 ? 'text-gray-400 cursor-not-allowed dark:text-gray-600'
                                 : 'text-gray-600 hover:text-yellow-400 dark:text-gray-400'
-                            }`}
+                              }`}
                             title="Play Voice Note"
                             whileHover={{ scale: audioLoading ? 1 : 1.1 }}
                             whileTap={{ scale: audioLoading ? 1 : 0.95 }}
@@ -1265,22 +1272,20 @@ const Gallery = () => {
               <button
                 onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
                 disabled={currentPage === 1}
-                className={`relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md ${
-                  currentPage === 1
-                    ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
-                    : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
-                }`}
+                className={`relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md ${currentPage === 1
+                  ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                  }`}
               >
                 Previous
               </button>
               <button
                 onClick={() => setCurrentPage(currentPage + 1)}
                 disabled={!hasMore}
-                className={`ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md ${
-                  !hasMore
-                    ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
-                    : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
-                }`}
+                className={`ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md ${!hasMore
+                  ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                  }`}
               >
                 Next
               </button>
@@ -1299,11 +1304,10 @@ const Gallery = () => {
                   <button
                     onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
                     disabled={currentPage === 1}
-                    className={`relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 dark:border-gray-600 text-sm font-medium ${
-                      currentPage === 1
-                        ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
-                        : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
-                    }`}
+                    className={`relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 dark:border-gray-600 text-sm font-medium ${currentPage === 1
+                      ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
+                      : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
+                      }`}
                   >
                     <span className="sr-only">Previous</span>
                     <ChevronLeftIcon className="h-5 w-5" aria-hidden="true" />
@@ -1322,11 +1326,10 @@ const Gallery = () => {
                         )}
                         <button
                           onClick={() => setCurrentPage(pageNum)}
-                          className={`relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium ${
-                            currentPage === pageNum
-                              ? 'z-10 bg-yellow-400 border-yellow-500 text-black'
-                              : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
-                          }`}
+                          className={`relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium ${currentPage === pageNum
+                            ? 'z-10 bg-yellow-400 border-yellow-500 text-black'
+                            : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
+                            }`}
                         >
                           {pageNum}
                         </button>
@@ -1337,11 +1340,10 @@ const Gallery = () => {
                   <button
                     onClick={() => setCurrentPage(currentPage + 1)}
                     disabled={!hasMore}
-                    className={`relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 dark:border-gray-600 text-sm font-medium ${
-                      !hasMore
-                        ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
-                        : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
-                    }`}
+                    className={`relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 dark:border-gray-600 text-sm font-medium ${!hasMore
+                      ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
+                      : 'bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
+                      }`}
                   >
                     <span className="sr-only">Next</span>
                     <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -478,9 +478,7 @@ const handleDownload = async (filename: string, type: 'file' | 'audio' = 'file')
       // Audio uses /api/audio/, images use /api/files/
       const endpoint = type === 'audio' ? `/api/audio/${filename}` : `/api/files/${filename}`;
       
-      const response = await fetch(apiUrl(endpoint), {
-        headers: { 'Authorization': `Bearer ${getToken()}` }
-      });
+      const response = await authenticatedFetch(endpoint);
       
       if (!response.ok) throw new Error('Download failed');
       

--- a/frontend/src/pages/admin/UserUploads.tsx
+++ b/frontend/src/pages/admin/UserUploads.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getToken } from '../../utils/auth';
 import { motion } from 'framer-motion';
@@ -28,7 +28,6 @@ const UserUploads = () => {
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [currentAudio, setCurrentAudio] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
 
 
   const [currentPage, setCurrentPage] = useState(1);
@@ -116,18 +115,8 @@ const UserUploads = () => {
 
   const handleAudioClick = (audioFilename: string) => {
     if (currentAudio === audioFilename) {
-      // If clicking the same audio, stop it
-      if (audioRef.current) {
-        audioRef.current.pause();
-        audioRef.current.currentTime = 0;
-      }
       setCurrentAudio(null);
     } else {
-      // If clicking a different audio, stop current and play new
-      if (audioRef.current) {
-        audioRef.current.pause();
-        audioRef.current.currentTime = 0;
-      }
       setCurrentAudio(audioFilename);
     }
   };

--- a/frontend/src/pages/admin/UserUploads.tsx
+++ b/frontend/src/pages/admin/UserUploads.tsx
@@ -160,7 +160,8 @@ const UserUploads = () => {
       const endpoint = type === 'audio' ? `/api/audio/${filename}` : `/api/files/${filename}`;
 
       const response = await fetch(apiUrl(endpoint), {
-        headers: { 'Authorization': `Bearer ${getToken()}` }
+        headers: { 'Authorization': `Bearer ${getToken()}` },
+        credentials: 'include'
       });
 
       if (!response.ok) throw new Error('Download failed');

--- a/frontend/src/pages/admin/UserUploads.tsx
+++ b/frontend/src/pages/admin/UserUploads.tsx
@@ -6,6 +6,7 @@ import Pagination from '../../components/ui/Pagination';
 import { ArrowLeftIcon, XMarkIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 import { toast } from 'react-hot-toast';
 import { apiUrl } from '../../utils/api';
+import { ProtectedMedia, ProtectedAudio } from '../../components/ProtectedRoutes';
 
 interface Upload {
   id: string;
@@ -28,8 +29,8 @@ const UserUploads = () => {
   const [currentAudio, setCurrentAudio] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  
-  
+
+
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
@@ -39,15 +40,15 @@ const UserUploads = () => {
   // Fetch uploads with pagination
   const fetchUploads = useCallback(async (page: number = 1, append: boolean = false) => {
     if (!userId) return;
-    
+
     try {
       if (page === 1) {
         setLoading(true);
       } else {
         setLoadingMore(true);
       }
-      
-      
+
+
       const response = await fetch(apiUrl(`/api/admin/user_uploads/${userId}?page=${page}&page_size=${pageSize}`), {
         method: 'GET',
         headers: {
@@ -57,31 +58,31 @@ const UserUploads = () => {
         credentials: 'include',
         mode: 'cors'
       });
-      
+
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
-      
+
       const data = await response.json();
       console.log(data);
       if (data.error) {
         throw new Error(data.error);
       }
-      
+
       const sortedImages: Upload[] = data.images.sort((a: Upload, b: Upload) =>
         new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
       );
-      
+
       if (append) {
         setUploads(prev => [...prev, ...sortedImages]);
       } else {
         setUploads(sortedImages);
       }
-      
+
       setTotalPages(data.totalPages || 1);
       setTotalCount(data.total_count || 0);
       setCurrentPage(data.page || 1);
-      
+
       console.log(`Loaded page ${page}/${data.totalPages}, ${sortedImages.length} uploads`);
     } catch (error) {
       console.error('Error fetching uploads:', error);
@@ -142,32 +143,44 @@ const UserUploads = () => {
 
   const renderFilePreview = () => {
     if (!selectedFile) return null;
-
-    const fileUrl = apiUrl(`/static/uploads/${selectedFile}`);
-
-    if (isPDF(selectedFile)) {
-      return (
-        <iframe
-          src={fileUrl}
-          className="w-full h-[80vh]"
-          title="PDF Preview"
-        />
-      );
-    }
+    const isPdfFile = isPDF(selectedFile);
 
     return (
-      <img
-        src={fileUrl}
-        alt="Uploaded file"
-        className="max-w-full h-auto mx-auto"
+      <ProtectedMedia
+        filename={selectedFile}
+        isPdf={isPdfFile}
+        className={isPdfFile ? "w-full h-[80vh]" : "max-w-full h-auto mx-auto"}
       />
     );
   };
 
-  const handleDownload = (filename: string, type: 'file' | 'audio') => {
-    const url = apiUrl(`/static/uploads/${filename}`);
-    window.open(url, '_blank');
-    toast.success(`${type === 'file' ? 'File' : 'Audio'} opened in new window!`);
+  const handleDownload = async (filename: string, type: 'file' | 'audio' = 'file') => {
+    try {
+      // Audio uses /api/audio/, images use /api/files/
+      const endpoint = type === 'audio' ? `/api/audio/${filename}` : `/api/files/${filename}`;
+
+      const response = await fetch(apiUrl(endpoint), {
+        headers: { 'Authorization': `Bearer ${getToken()}` }
+      });
+
+      if (!response.ok) throw new Error('Download failed');
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.style.display = 'none';
+      a.href = url;
+      a.download = filename; // download instead of opening in tab
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+
+      toast.success(`${type === 'file' ? 'File' : 'Audio'} downloaded successfully!`);
+    } catch (error) {
+      console.error('Download error:', error);
+      toast.error('Failed to download file.');
+    }
   };
 
   return (
@@ -277,25 +290,20 @@ const UserUploads = () => {
                           <div className="flex flex-col space-y-2">
                             <button
                               onClick={() => handleAudioClick(upload.audio_filename!)}
-                              className={`inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium transition-colors duration-200 ${
-                                currentAudio === upload.audio_filename 
-                                  ? 'bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900 dark:text-red-100 dark:hover:bg-red-800' 
+                              className={`inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium transition-colors duration-200 ${currentAudio === upload.audio_filename
+                                  ? 'bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900 dark:text-red-100 dark:hover:bg-red-800'
                                   : 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900 dark:text-blue-100 dark:hover:bg-blue-800'
-                              }`}
+                                }`}
                             >
                               {currentAudio === upload.audio_filename ? 'Hide Player' : 'Show Player'}
                             </button>
                             {currentAudio === upload.audio_filename && (
                               <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-3 border border-gray-200 dark:border-gray-700">
-                                <audio
-                                  ref={audioRef}
-                                  controls
+                                <ProtectedAudio
+                                  filename={upload.audio_filename}
                                   className="w-full [&::-webkit-media-controls-panel]:bg-gray-100 dark:[&::-webkit-media-controls-panel]:bg-gray-800 [&::-webkit-media-controls-current-time-display]:text-gray-700 dark:[&::-webkit-media-controls-current-time-display]:text-gray-300 [&::-webkit-media-controls-time-remaining-display]:text-gray-700 dark:[&::-webkit-media-controls-time-remaining-display]:text-gray-300 [&::-webkit-media-controls-timeline]:bg-gray-300 dark:[&::-webkit-media-controls-timeline]:bg-gray-600 [&::-webkit-media-controls-volume-slider]:bg-gray-300 dark:[&::-webkit-media-controls-volume-slider]:bg-gray-600"
-                                  src={apiUrl(`/static/uploads/${upload.audio_filename}`)}
                                   onEnded={() => setCurrentAudio(null)}
-                                >
-                                  Your browser does not support the audio element.
-                                </audio>
+                                />
                               </div>
                             )}
                           </div>
@@ -334,11 +342,11 @@ const UserUploads = () => {
             )}
           </div>
 
-            <div className="p-4">
-              <Pagination page={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
-            </div>
-          
-          
+          <div className="p-4">
+            <Pagination page={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+          </div>
+
+
 
           {/* Loading indicator */}
           {loadingMore && (


### PR DESCRIPTION
#### Fixes: #603 

**Description of your changes:**
This pull request fixes a security bug where user-uploaded media (e.g., images, PDFs, audio) were publicly accessible. Previously, the media were being stored under the Flask `static/uploads` folder, which allowed them to bypass all JWT-based authentication and `@require_auth` decorators.
This change moves all user uploads to a secure location under the root directory and adds secure routes for fetching the media by authorized users.

**Changes Made:**

- Added `get_image_by_filename` in userdatahandler.py to map files and thumbnails to their respective owners.
- Created a new `@require_auth route (/api/files/<path:filename>)` in app.py. This route verifies that the requesting user either owns the file or has admin privileges before using `send_from_directory()`.
- Created `<ProtectedMedia />` and `<ProtectedAudio />` components to pass the user's JWT in the Authorization header.

**Checklist:**
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
