### PR TITLE
Fix: Admin uploads pagination failing

### DIFF
--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -258,8 +258,15 @@ def _get_paginated_images_by_user(user_id, page=1, page_size=12, filters=None):
         # Calculate skip for pagination
         skip = (page - 1) * page_size
         
-        # Build query
-        query = {'user_id': user_id}
+        # Build query using both string and ObjectId user ID forms for compatibility.
+        user_id_candidates = {user_id}
+        try:
+            user_id_candidates.add(ObjectId(user_id))
+        except Exception:
+            # Keep compatibility with legacy/non-ObjectId identifiers.
+            pass
+
+        query = {'user_id': {'$in': list(user_id_candidates)}}
         
         # Apply filters if provided
         if filters:

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -262,7 +262,7 @@ def _get_paginated_images_by_user(user_id, page=1, page_size=12, filters=None):
         user_id_candidates = {user_id}
         try:
             user_id_candidates.add(ObjectId(user_id))
-        except Exception:
+        except (TypeError, ValueError):
             # Keep compatibility with legacy/non-ObjectId identifiers.
             pass
 

--- a/database/userdatahandler.py
+++ b/database/userdatahandler.py
@@ -152,17 +152,33 @@ def _parse_iso_date(date_string, field_name):
         raise ValueError(f"Invalid '{field_name}' date format: {date_string}. Expected ISO format.")
 
 
+def _build_user_id_query(user_id):
+    """
+    Build a MongoDB query that supports both string and ObjectId user IDs.
+    
+    This helper ensures compatibility with legacy string-based user IDs while
+    also supporting ObjectId formatted IDs, providing flexibility across the codebase.
+    
+    Args:
+        user_id: User ID (can be string or ObjectId)
+    
+    Returns:
+        dict: MongoDB query dictionary with '$in' operator for flexible user_id matching
+    """
+    user_id_candidates = {user_id}
+    try:
+        user_id_candidates.add(ObjectId(user_id))
+    except (TypeError, ValueError):
+        # Keep compatibility with legacy/non-ObjectId identifiers.
+        pass
+    
+    return {'user_id': {'$in': list(user_id_candidates)}}
+
+
 def search_and_filter_images(user_id, search_query=None, sentiment=None, from_date=None, to_date=None, 
                              sort_by='date', sort_order='desc', limit=12, offset=0):
     try:
-        user_id_candidates = {user_id}
-        try:
-            user_id_candidates.add(ObjectId(user_id))
-        except (TypeError, ValueError):
-            # This can happen with legacy string-based user IDs
-            pass
-
-        query = {'user_id': {'$in': list(user_id_candidates)}}
+        query = _build_user_id_query(user_id)
         update_last_seen(user_id)
         if search_query and search_query.strip():
             query['$text'] = {'$search': search_query.strip()}
@@ -259,14 +275,7 @@ def _get_paginated_images_by_user(user_id, page=1, page_size=12, filters=None):
         skip = (page - 1) * page_size
         
         # Build query using both string and ObjectId user ID forms for compatibility.
-        user_id_candidates = {user_id}
-        try:
-            user_id_candidates.add(ObjectId(user_id))
-        except (TypeError, ValueError):
-            # Keep compatibility with legacy/non-ObjectId identifiers.
-            pass
-
-        query = {'user_id': {'$in': list(user_id_candidates)}}
+        query = _build_user_id_query(user_id)
         
         # Apply filters if provided
         if filters:

--- a/frontend/src/pages/admin/UserUploads.tsx
+++ b/frontend/src/pages/admin/UserUploads.tsx
@@ -68,7 +68,8 @@ const UserUploads = () => {
         throw new Error(data.error);
       }
       
-      const sortedImages: Upload[] = data.images.sort((a: Upload, b: Upload) =>
+      const images: Upload[] = Array.isArray(data.images) ? data.images : [];
+      const sortedImages: Upload[] = images.sort((a: Upload, b: Upload) =>
         new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
       );
       
@@ -78,11 +79,12 @@ const UserUploads = () => {
         setUploads(sortedImages);
       }
       
-      setTotalPages(data.totalPages || 1);
+      const normalizedTotalPages = typeof data.totalPages === 'number' ? data.totalPages : 0;
+      setTotalPages(normalizedTotalPages > 0 ? normalizedTotalPages : 1);
       setTotalCount(data.total_count || 0);
       setCurrentPage(data.page || 1);
       
-      console.log(`Loaded page ${page}/${data.totalPages}, ${sortedImages.length} uploads`);
+      console.log(`Loaded page ${page}/${normalizedTotalPages}, ${sortedImages.length} uploads`);
     } catch (error) {
       console.error('Error fetching uploads:', error);
       if (page === 1) {

--- a/frontend/src/pages/admin/UserUploads.tsx
+++ b/frontend/src/pages/admin/UserUploads.tsx
@@ -68,10 +68,7 @@ const UserUploads = () => {
         throw new Error(data.error);
       }
       
-      const images: Upload[] = Array.isArray(data.images) ? data.images : [];
-      const sortedImages: Upload[] = images.sort((a: Upload, b: Upload) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
+      const sortedImages: Upload[] = Array.isArray(data.images) ? data.images : [];
       
       if (append) {
         setUploads(prev => [...prev, ...sortedImages]);


### PR DESCRIPTION
### Summary

---
### Problem
Admin uploads page at `/admin/users/:userId/uploads` showed no data even when uploads existed.  
Frontend logs showed:
- `images: []`
- `total_count: 0`
- `totalPages: 0`

---

### Root Cause
Uploads are often stored with `user_id` as Mongo `ObjectId`, but admin pagination queried with `user_id` as a plain string only.  
This caused MongoDB exact-match queries to return zero records.

---

### Related Issue
- #592 



**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
