### PR TITLE
Fix: Admin user contract mismatch

### DIFF
--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -236,7 +236,6 @@ const Users = () => {
                               {user.name || 'N/A'}
                             </button>
                               <div className="text-sm text-gray-500 dark:text-gray-400">
-                                {user.email || 'N/A'}
                               </div>
                             </div>
                           </div>

--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -47,7 +47,13 @@ const normalizeUser = (user: ApiUser): User => {
   };
 };
 
-const csvEscape = (value: string) => `"${value.replace(/"/g, '""')}"`;
+const csvEscape = (value: string) => {
+  let cellContent = value;
+  if (['=', '+', '-', '@'].includes(cellContent.charAt(0))) {
+    cellContent = `'${cellContent}`;
+  }
+  return `"${cellContent.replace(/"/g, '""')}"`;
+};
 
 const Users = () => {
   const [users, setUsers] = useState<User[]>([]);

--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -22,6 +22,33 @@ interface User {
   image: string;
 }
 
+interface ApiUser {
+  id?: string;
+  user_id?: string;
+  name?: string;
+  email?: string;
+  role?: string;
+  lastActive?: string;
+  status?: string;
+  image?: string;
+}
+
+const normalizeUser = (user: ApiUser): User => {
+  const id = user.id || user.user_id || '';
+  return {
+    id,
+    user_id: user.user_id || id,
+    name: user.name || '',
+    email: user.email || '',
+    role: user.role || 'user',
+    lastActive: user.lastActive || '',
+    status: user.status || 'active',
+    image: user.image || '',
+  };
+};
+
+const csvEscape = (value: string) => `"${value.replace(/"/g, '""')}"`;
+
 const Users = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
@@ -56,9 +83,12 @@ const Users = () => {
       }
       
       const data = await response.json();
-      setUsers(data.users);
+      const normalizedUsers = Array.isArray(data.users)
+        ? data.users.map((user: ApiUser) => normalizeUser(user))
+        : [];
+      setUsers(normalizedUsers);
       // console.log(data.users);
-      setTotalCount(data.totalCount);
+      setTotalCount(Number(data.totalCount) || 0);
     } catch (error) {
       console.error('Error fetching users:', error);
       toast.error('Failed to fetch users');
@@ -88,13 +118,13 @@ const Users = () => {
       // Create CSV content
       const headers = ['Name', 'Email', 'Role', 'Last Active'];
       const csvContent = [
-        headers.join(','), // Header row
+        headers.map(csvEscape).join(','), // Header row
         ...users.map(user => [
           user.name,
           user.email,
           user.role,
           user.lastActive ? new Date(user.lastActive).toLocaleString() : 'Never'
-        ].join(','))
+        ].map(csvEscape).join(','))
       ].join('\n');
 
       // Create blob and download
@@ -200,7 +230,7 @@ const Users = () => {
                               {user.name || 'N/A'}
                             </button>
                               <div className="text-sm text-gray-500 dark:text-gray-400">
-                                {user.email}
+                                {user.email || 'N/A'}
                               </div>
                             </div>
                           </div>

--- a/routes/adminroutes.py
+++ b/routes/adminroutes.py
@@ -138,6 +138,7 @@ def list_users():
                 "id": str(u.get("_id")),
                 "user_id": str(u.get("_id")),
                 "name": u.get("username") or u.get("email") or "Unknown User",
+                "email": u.get("email") or "",
                 "role": u.get("role", "user"),
                 "lastActive": u.get("last_active") or u.get("last_seen") or None,
                 "status": u.get("status", "active"),


### PR DESCRIPTION
### Summary

### Problem
Admin users API returned name but not email, while the admin Users page expected email for rendering and CSV export.

### Changes
- Backend: include email in admin users list response.
- Frontend: normalize incoming user payload before storing state and avoid blank email rendering .

### Before

<img width="399" height="111" alt="image" src="https://github.com/user-attachments/assets/93b420c5-c22b-422e-847f-0f468e61a6ea" />

### After

<img width="471" height="106" alt="image" src="https://github.com/user-attachments/assets/09976869-26f7-47c8-8a06-fb56ed20a6cc" />
 
---
**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
