### PR TITLE
fix: handle missing python-magic dependency during app import

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,11 @@ from utils.logger import logger as app_logger
 
 import fitz
 import google.generativeai as genai
-import magic
+try:
+    import magic
+except ImportError:
+    magic = None
+    app_logger.warning("python-magic is not installed; MIME detection is unavailable until dependency is installed.")
 from bson import ObjectId
 from bson.errors import InvalidId
 from flask import (
@@ -360,6 +364,8 @@ def upload_images():
         if MAGIC is not None:
             mime_detector = MAGIC
         else:
+            if magic is None:
+                return jsonify({"error": "Server MIME detection unavailable; contact administrator."}), 500
             global _FALLBACK_MAGIC
             if _FALLBACK_MAGIC is None:
                 try:

--- a/tests/test_magic_import.py
+++ b/tests/test_magic_import.py
@@ -1,0 +1,11 @@
+import importlib
+import sys
+
+
+def test_app_imports_without_python_magic(monkeypatch):
+    monkeypatch.setitem(sys.modules, "magic", None)
+    sys.modules.pop("app", None)
+
+    imported_app = importlib.import_module("app")
+
+    assert imported_app.app is not None

--- a/tests/test_magic_import.py
+++ b/tests/test_magic_import.py
@@ -1,11 +1,14 @@
 import importlib
 import sys
+import logging
 
 
-def test_app_imports_without_python_magic(monkeypatch):
-    monkeypatch.setitem(sys.modules, "magic", None)
+def def test_app_imports_without_python_magic(monkeypatch, caplog):
+    monkeypatch.delitem(sys.modules, "magic", raising=False)
+    monkeypatch.syspath_prepend("/path/that/does/not/exist")
     sys.modules.pop("app", None)
 
     imported_app = importlib.import_module("app")
 
     assert imported_app.app is not None
+    assert "python-magic is not installed; MIME detection is unavailable until dependency is installed." in caplog.text


### PR DESCRIPTION
## What:

This pull request fixes an import-time failure when the optional `python-magic` dependency is not installed.

## Why:

Currently, the application crashes during startup because `magic` is imported at module level. This prevents tests from running and blocks local development environments where `libmagic` is unavailable.

## How:

* Wrapped `import magic` in a try/except block and fallback to `None` if unavailable
* Added a warning log when MIME detection is not available
* Guarded usage of `magic.Magic(...)` to prevent runtime errors
* Added a test to verify the application initializes successfully when `magic` is missing

