### PR TITLE
Remove unused and duplicate imports in auth.py

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,4 +1,3 @@
-import re
 from flask import Blueprint, request, jsonify, current_app
 from datetime import datetime, timedelta, timezone
 import secrets
@@ -8,7 +7,7 @@ from google.auth.transport import requests as google_requests
 
 from utils.validation import validate_email, validate_otp, sanitize_string, ValidationError
 from database.databaseConfig import db
-from database.userdatahandler import create_user, get_user_by_username, update_last_seen
+from database.userdatahandler import update_last_seen
 from utils.roles import is_admin_email
 from utils.jwt_auth import create_access_token
 from database.databaseConfig import beehive
@@ -77,8 +76,6 @@ def request_otp():
         current_app.logger.exception("Failed to send OTP email: %s", e)
         return jsonify({"message": "OTP stored (failed to send email)"}), 200
 
-
-from datetime import datetime, timezone
 
 @auth_bp.route("/verify-otp", methods=["POST"], strict_slashes=False)
 def verify_otp():


### PR DESCRIPTION
## What:

This pull request removes unused and duplicate imports from the auth routes module.

## Why:

Unused and duplicate imports add unnecessary noise and can make the code harder to read and maintain, especially in authentication-related code.

## How:

* Removed unused imports (`re`, `create_user`, `get_user_by_username`)
* Removed duplicate `datetime` import
* No changes to existing logic or behavior
