### PR TITLE
Update api docs for /api/admin/users

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -72,9 +72,7 @@ Side effects:
 - **Description**: List users from the local MongoDB `users` collection.
 - **Query**: `query` (search), `limit` (default 10), `offset` (default 0)
 - **Responses**:
-  - 200: `{ users: [{ id, user_id, name, role, lastActive, status, image, clerkId }], totalCount }`
-  - 500: `{ error: "Failed to list users" }`
-- **Notes**: `name` is derived from `username` or `email`; `email` is not returned as a separate field.
+  
 
 #### GET `/api/admin/users/only-users`
 - As above, but filters to `role === 'user'`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,9 +72,9 @@ Side effects:
 - **Description**: List users from the local MongoDB `users` collection.
 - **Query**: `query` (search), `limit` (default 10), `offset` (default 0)
 - **Responses**:
-  - 200: `{ users: [{ id, username, email, role, lastActive, image }], totalCount }`
-  - 500: `{ error: "Failed to fetch users" }`
- - **Notes**: No external Clerk dependency; the backend reads users from MongoDB.
+  - 200: `{ users: [{ id, user_id, name, role, lastActive, status, image, clerkId }], totalCount }`
+  - 500: `{ error: "Failed to list users" }`
+- **Notes**: `name` is derived from `username` or `email`; `email` is not returned as a separate field.
 
 #### GET `/api/admin/users/only-users`
 - As above, but filters to `role === 'user'`.
@@ -157,4 +157,3 @@ Side effects:
 ## Protected Routes
 All routes except home, login and register require authentication.
 Admin routes require Google OAuth authentication.
-


### PR DESCRIPTION
## What:

This pull request updates the API documentation for the `/api/admin/users` endpoint to match the actual response structure.

## Why:

The current documentation includes fields (such as `email`) that are not returned by the endpoint, which can lead to confusion during frontend or integration work.

## How:

* Reviewed the current implementation of `/api/admin/users`
* Updated the documented response fields to reflect the actual output
* No changes to backend behavior
