### PR TITLE
Refactor login fixture into user factory

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -240,11 +240,11 @@ def login():
     })
 
     if not user:
-        return jsonify({"error": "User not found"}), 401
+        return jsonify({"error": "Invalid credentials"}), 401
 
     stored_password = user.get("password")
     if not stored_password:
-        return jsonify({"error": "Password not set"}), 400
+        return jsonify({"error": "Invalid credentials"}), 401
 
     if not bcrypt.checkpw(password.encode(), stored_password):
         return jsonify({"error": "Invalid credentials"}), 401

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,68 +1,92 @@
 import bcrypt
 import pytest
 
-
 @pytest.fixture
 def created_user(mock_db):
-    """Fixture factory to create users in the mock database."""
+def _make_user(email="[test@example.com](mailto:test@example.com)", username="testuser", password="securepassword"):
+stored_password = None if password is None else bcrypt.hashpw(
+password.encode("utf-8"), bcrypt.gensalt()
+)
 
-    def _create_user(email="test@example.com", username="testuser", password="securepassword"):
-        stored_password = None if password is None else bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt())
-        user_data = {"email": email, "username": username, "password": stored_password}
-        mock_db.users.insert_one(user_data)
-        return {"email": email, "username": username, "password": password}
+```
+    user_data = {
+        "email": email,
+        "username": username,
+        "password": stored_password,
+    }
 
-    default_user = _create_user()
+    mock_db.users.insert_one(user_data)
 
-    class _UserFactory:
-        def __call__(self, **kwargs):
-            return _create_user(**kwargs)
+    return {
+        "email": email,
+        "username": username,
+        "password": password,
+    }
 
-        def __getitem__(self, key):
-            return default_user[key]
-
-    return _UserFactory()
-
+return _make_user
+```
 
 @pytest.mark.parametrize("login_identifier_key", ["email", "username"])
 def test_login_success(client, created_user, login_identifier_key):
-    """
-    POST /api/auth/login with valid credentials (email or username).
-    """
-    response = client.post(
-        "/api/auth/login",
-        json={
-            "username": created_user[login_identifier_key],
-            "password": created_user["password"],
-        },
-    )
+"""
+POST /api/auth/login with valid credentials (email or username).
+"""
+user = created_user()
 
-    assert response.status_code == 200
-    data = response.get_json()
-    assert "access_token" in data
+```
+response = client.post(
+    "/api/auth/login",
+    json={
+        "username": user[login_identifier_key],
+        "password": user["password"],
+    },
+)
 
+assert response.status_code == 200
+data = response.get_json()
+assert "access_token" in data
+```
 
 @pytest.mark.parametrize(
-    "username,password",
-    [("missing@example.com", "wrongpassword"), ("test@example.com", "wrongpassword")],
+"username,password",
+[
+("[missing@example.com](mailto:missing@example.com)", "wrongpassword"),
+("[test@example.com](mailto:test@example.com)", "wrongpassword"),
+],
 )
 def test_login_invalid_credentials(client, created_user, username, password):
-    """POST /api/auth/login - all authentication failures should return generic 401."""
-    response = client.post("/api/auth/login", json={"username": username, "password": password})
+"""POST /api/auth/login - all authentication failures should return generic 401."""
+# Create a valid user so DB is not empty
+created_user()
 
-    assert response.status_code == 401
-    data = response.get_json()
-    assert data == {"error": "Invalid credentials"}
+```
+response = client.post(
+    "/api/auth/login",
+    json={"username": username, "password": password},
+)
 
+assert response.status_code == 401
+data = response.get_json()
+assert data == {"error": "Invalid credentials"}
+```
 
 def test_login_user_without_password(client, created_user):
-    """POST /api/auth/login - users without local password should get generic 401."""
-    oauth_user = created_user(email="oauth@example.com", username="oauthuser", password=None)
+"""POST /api/auth/login - users without local password should get generic 401."""
+oauth_user = created_user(
+email="[oauth@example.com](mailto:oauth@example.com)",
+username="oauthuser",
+password=None,
+)
 
-    response = client.post(
-        "/api/auth/login",
-        json={"username": oauth_user["email"], "password": "somepassword"},
-    )
+```
+response = client.post(
+    "/api/auth/login",
+    json={
+        "username": oauth_user["email"],
+        "password": "somepassword",
+    },
+)
 
-    assert response.status_code == 401
-    assert response.get_json() == {"error": "Invalid credentials"}
+assert response.status_code == 401
+assert response.get_json() == {"error": "Invalid credentials"}
+```

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -4,16 +4,24 @@ import pytest
 
 @pytest.fixture
 def created_user(mock_db):
-    """Fixture to create a user in the mock database."""
-    password = "securepassword"
-    hashed_pw = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())
-    user_data = {
-        "email": "test@example.com",
-        "username": "testuser",
-        "password": hashed_pw,
-    }
-    mock_db.users.insert_one(user_data)
-    return {"email": user_data["email"], "username": user_data["username"], "password": password}
+    """Fixture factory to create users in the mock database."""
+
+    def _create_user(email="test@example.com", username="testuser", password="securepassword"):
+        stored_password = None if password is None else bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt())
+        user_data = {"email": email, "username": username, "password": stored_password}
+        mock_db.users.insert_one(user_data)
+        return {"email": email, "username": username, "password": password}
+
+    default_user = _create_user()
+
+    class _UserFactory:
+        def __call__(self, **kwargs):
+            return _create_user(**kwargs)
+
+        def __getitem__(self, key):
+            return default_user[key]
+
+    return _UserFactory()
 
 
 @pytest.mark.parametrize("login_identifier_key", ["email", "username"])
@@ -34,13 +42,27 @@ def test_login_success(client, created_user, login_identifier_key):
     assert "access_token" in data
 
 
-def test_login_invalid_credentials(client, created_user):
-    """POST /api/auth/login - invalid credentials should return 401"""
-    response = client.post(
-        "/api/auth/login",
-        json={"username": created_user["email"], "password": "wrongpassword"},
-    )
+@pytest.mark.parametrize(
+    "username,password",
+    [("missing@example.com", "wrongpassword"), ("test@example.com", "wrongpassword")],
+)
+def test_login_invalid_credentials(client, created_user, username, password):
+    """POST /api/auth/login - all authentication failures should return generic 401."""
+    response = client.post("/api/auth/login", json={"username": username, "password": password})
 
     assert response.status_code == 401
     data = response.get_json()
-    assert "access_token" not in data
+    assert data == {"error": "Invalid credentials"}
+
+
+def test_login_user_without_password(client, created_user):
+    """POST /api/auth/login - users without local password should get generic 401."""
+    oauth_user = created_user(email="oauth@example.com", username="oauthuser", password=None)
+
+    response = client.post(
+        "/api/auth/login",
+        json={"username": oauth_user["email"], "password": "somepassword"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Invalid credentials"}


### PR DESCRIPTION
Unified login authentication failure responses to always return:

{"error": "Invalid credentials"}
Applied this to failure cases where:

user is not found

user has no local password

password is incorrect

Refactored login test setup to use a factory-style created_user fixture that supports overrides (including password=None for OAuth-style users).

Updated login tests to validate consistent generic failure behavior, including the no-password user case.

Why
Prevents user enumeration and account-state disclosure by removing distinguishable login error messages.

Ensures the API presents a single, consistent authentication failure response.

Improves test consistency and maintainability by avoiding direct DB insertion in individual tests and reusing fixture-driven setup.

How
In routes/auth.py, replaced distinct auth failure payloads in the login path with the generic {"error": "Invalid credentials"} and consistent 401 responses.

In tests/test_login.py:

converted created_user into a callable fixture/factory with sensible defaults

added support for password=None to model OAuth/non-password users

updated test_login_user_without_password to use created_user(password=None) instead of direct mock_db.users.insert_one(...)

kept existing tests working with minimal behavioral change while aligning assertions to the unified auth error response