### PR TITLE
Fix: use correct API route for audio requests

### DIFF
--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -108,8 +108,8 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
       setError(false);
       try {
         const token = getToken();
-        const response = await fetch(encodeURI(apiUrl('/api/audio/' + filename)), {
-          headers: token ? { 'Authorization': 'Bearer ' + token } : {},
+        const response = await fetch(encodeURI(apiUrl(`/api/audio/${encodeURIComponent(filename)}`)), {
+          headers: token ? { 'Authorization': `Bearer ${token}` } : {},
           credentials: 'include'
         });
 

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -101,11 +101,14 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
 
   useEffect(() => {
     let objectUrl: string | null = null;
+    let isCancelled = false;
+
+    // Always reset when filename changes, including when it becomes empty.
+    setSrc(null);
+    setError(false);
 
     const fetchAudio = async () => {
       try {
-        setSrc(null);
-        setError(false);
         const token = getToken();
         const response = await fetch(encodeURI(apiUrl(`/api/audio/${filename}`)), {
           headers: token ? { 'Authorization': `Bearer ${token}` } : {},
@@ -117,9 +120,12 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
         }
 
         const blob = await response.blob();
+        if (isCancelled) return;
+
         objectUrl = URL.createObjectURL(blob);
         setSrc(objectUrl);
       } catch (error) {
+        if (isCancelled) return;
         console.error("Failed to load secure audio", error);
         setError(true);
       }
@@ -130,6 +136,7 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
     }
 
     return () => {
+      isCancelled = true;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [filename]);

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -97,35 +97,44 @@ export const ProtectedMedia = ({ filename, isPdf = false, className = '', alt = 
 
 export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedAudioProps) => {
   const [src, setSrc] = useState<string | null>(null);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     let objectUrl: string | null = null;
 
     const fetchAudio = async () => {
       try {
+        setSrc(null);
+        setError(false);
         const token = getToken();
-        const response = await fetch(encodeURI(apiUrl(`/audio/${filename}`)), {
+        const response = await fetch(encodeURI(apiUrl(`/api/audio/${filename}`)), {
           headers: token ? { 'Authorization': `Bearer ${token}` } : {},
           credentials: 'include'
         });
 
-        if (response.ok) {
-          const blob = await response.blob();
-          objectUrl = URL.createObjectURL(blob);
-          setSrc(objectUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to load audio (${response.status})`);
         }
+
+        const blob = await response.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
       } catch (error) {
         console.error("Failed to load secure audio", error);
+        setError(true);
       }
     };
 
-    fetchAudio();
+    if (filename) {
+      fetchAudio();
+    }
 
     return () => {
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [filename]);
 
+  if (error) return <div className="text-sm text-red-500 p-2">Failed to load secure audio.</div>;
   if (!src) return <div className="text-sm text-gray-500 p-2 animate-pulse">Loading secure audio...</div>;
 
   return (

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -103,20 +103,18 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
     let objectUrl: string | null = null;
     let isCancelled = false;
 
-    // Always reset when filename changes, including when it becomes empty.
-    setSrc(null);
-    setError(false);
-
     const fetchAudio = async () => {
+      setSrc(null);
+      setError(false);
       try {
         const token = getToken();
-        const response = await fetch(encodeURI(apiUrl(`/api/audio/${filename}`)), {
-          headers: token ? { 'Authorization': `Bearer ${token}` } : {},
+        const response = await fetch(encodeURI(apiUrl('/api/audio/' + filename)), {
+          headers: token ? { 'Authorization': 'Bearer ' + token } : {},
           credentials: 'include'
         });
 
         if (!response.ok) {
-          throw new Error(`Failed to load audio (${response.status})`);
+          throw new Error('Failed to load audio (' + response.status + ')');
         }
 
         const blob = await response.blob();
@@ -126,13 +124,16 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
         setSrc(objectUrl);
       } catch (error) {
         if (isCancelled) return;
-        console.error("Failed to load secure audio", error);
+        console.error('Failed to load secure audio', error);
         setError(true);
       }
     };
 
     if (filename) {
       fetchAudio();
+    } else {
+      setSrc(null);
+      setError(false);
     }
 
     return () => {

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -101,16 +101,17 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
 
   useEffect(() => {
     let objectUrl: string | null = null;
-    let isCancelled = false;
+    const controller = new AbortController();
 
     const fetchAudio = async () => {
       setSrc(null);
       setError(false);
       try {
         const token = getToken();
-        const response = await fetch(encodeURI(apiUrl(`/api/audio/${encodeURIComponent(filename)}`)), {
+        const response = await fetch(apiUrl(`/api/audio/${encodeURIComponent(filename)}`), {
           headers: token ? { 'Authorization': `Bearer ${token}` } : {},
-          credentials: 'include'
+          credentials: 'include',
+          signal: controller.signal
         });
 
         if (!response.ok) {
@@ -118,12 +119,12 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
         }
 
         const blob = await response.blob();
-        if (isCancelled) return;
+        if (controller.signal.aborted) return;
 
         objectUrl = URL.createObjectURL(blob);
         setSrc(objectUrl);
       } catch (error) {
-        if (isCancelled) return;
+        if (error instanceof DOMException && error.name === 'AbortError') return;
         console.error('Failed to load secure audio', error);
         setError(true);
       }
@@ -137,7 +138,7 @@ export const ProtectedAudio = ({ filename, className = '', onEnded }: ProtectedA
     }
 
     return () => {
-      isCancelled = true;
+      controller.abort();
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [filename]);

--- a/frontend/src/pages/admin/UserUploads.tsx
+++ b/frontend/src/pages/admin/UserUploads.tsx
@@ -147,7 +147,7 @@ const UserUploads = () => {
   const handleDownload = async (filename: string, type: 'file' | 'audio' = 'file') => {
     try {
       // Audio uses /api/audio/, images use /api/files/
-      const endpoint = type === 'audio' ? '/api/audio/' + filename : '/api/files/' + filename;
+      const endpoint = type === 'audio' ? '/api/audio/' + encodeURIComponent(filename) : '/api/files/' + encodeURIComponent(filename);
 
       const response = await fetch(apiUrl(endpoint), {
         headers: { 'Authorization': `Bearer ${getToken()}` },

--- a/frontend/src/pages/admin/UserUploads.tsx
+++ b/frontend/src/pages/admin/UserUploads.tsx
@@ -147,7 +147,7 @@ const UserUploads = () => {
   const handleDownload = async (filename: string, type: 'file' | 'audio' = 'file') => {
     try {
       // Audio uses /api/audio/, images use /api/files/
-      const endpoint = type === 'audio' ? '/audio/' + filename : '/api/files/' + filename;
+      const endpoint = type === 'audio' ? '/api/audio/' + filename : '/api/files/' + filename;
 
       const response = await fetch(apiUrl(endpoint), {
         headers: { 'Authorization': `Bearer ${getToken()}` },


### PR DESCRIPTION
### Summary

### Problem
- Secure audio requests were sent to an incorrect endpoint (`/audio/:filename` instead of `/api/audio/:filename`)
- Admin audio download used a non-API route for audio files.
- On fetch failure, the component did not transition to an error UI.

### Changes
- Updated protected audio fetch endpoint from `/audio/:filename` to `/api/audio/:filename` in ProtectedRoutes component.
- Added state reset before each fetch attempt to avoid stale UI.

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
