### PR TITLE
refactor: remove custom db implementation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,6 @@ TEST_SECRET_KEY = 'test-secret-key-minimum-32-chars-long-for-pytest'
 os.environ['FLASK_SECRET_KEY'] = TEST_SECRET_KEY
 os.environ['JWT_SECRET'] = TEST_SECRET_KEY
 
-from app import app as flask_app
-
 
 @pytest.fixture(scope='session', autouse=True)
 def mock_mongo_client_session():
@@ -19,14 +17,17 @@ def mock_mongo_client_session():
 @pytest.fixture(autouse=True)
 def mock_db(mock_mongo_client_session):
     from database.databaseConfig import db
-    # Clear all collections
+    # ensure a clean state before each test
     for collection in db.list_collection_names():
-        db.drop_collection(collection)
+        db[collection].delete_many({})
+
     yield db
 
 
 @pytest.fixture
 def app(mock_mongo_client_session):
+    # app was imported lazily so the mongo patch is already active at import time.
+    from app import app as flask_app
     flask_app.config.update({
         "TESTING": True,
         "SECRET_KEY": TEST_SECRET_KEY,

--- a/tests/test_auth_otp_security.py
+++ b/tests/test_auth_otp_security.py
@@ -1,67 +1,11 @@
 from datetime import datetime, timedelta, timezone
 
 import bcrypt
-import routes.auth as auth_module
 
 
-class _InsertResult:
-    def __init__(self, inserted_id):
-        self.inserted_id = inserted_id
-
-
-class _Collection:
-    def __init__(self):
-        self._docs = []
-        self._next_id = 1
-
-    def _matches(self, doc, query):
-        for key, value in query.items():
-            if doc.get(key) != value:
-                return False
-        return True
-
-    def find_one(self, query, sort=None):
-        matches = [doc for doc in self._docs if self._matches(doc, query)]
-        if not matches:
-            return None
-
-        if sort:
-            field, direction = sort[0]
-            reverse = direction == -1
-            matches.sort(key=lambda d: d.get(field) or datetime.min.replace(tzinfo=timezone.utc), reverse=reverse)
-
-        return matches[0]
-
-    def insert_one(self, doc):
-        new_doc = dict(doc)
-        if "_id" not in new_doc:
-            new_doc["_id"] = self._next_id
-            self._next_id += 1
-        self._docs.append(new_doc)
-        return _InsertResult(new_doc["_id"])
-
-    def delete_many(self, query):
-        self._docs = [doc for doc in self._docs if not self._matches(doc, query)]
-
-    def update_one(self, query, update):
-        target = self.find_one(query)
-        if not target:
-            return
-        set_values = update.get("$set", {})
-        for key, value in set_values.items():
-            target[key] = value
-
-
-class _FakeDB:
-    def __init__(self):
-        self.users = _Collection()
-        self.email_otps = _Collection()
-
-
-
-def _seed_existing_user(fake_db, email, username="existing_user", password="OldPass@123"):
+def _seed_existing_user(mock_db, email, username="existing_user", password="OldPass@123"):
     hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt())
-    fake_db.users.insert_one(
+    mock_db.users.insert_one(
         {
             "email": email,
             "username": username,
@@ -73,8 +17,8 @@ def _seed_existing_user(fake_db, email, username="existing_user", password="OldP
 
 
 
-def _seed_otp_record(fake_db, email, otp="123456", expires_delta_minutes=5):
-    fake_db.email_otps.insert_one(
+def _seed_otp_record(mock_db, email, otp="123456", expires_delta_minutes=5):
+    mock_db.email_otps.insert_one(
         {
             "email": email,
             "otp": otp,
@@ -84,8 +28,8 @@ def _seed_otp_record(fake_db, email, otp="123456", expires_delta_minutes=5):
 
 
 
-def _seed_verified_otp_record(fake_db, email, verified_minutes_ago=1):
-    fake_db.email_otps.insert_one(
+def _seed_verified_otp_record(mock_db, email, verified_minutes_ago=1):
+    mock_db.email_otps.insert_one(
         {
             "email": email,
             "otp": "123456",
@@ -97,10 +41,7 @@ def _seed_verified_otp_record(fake_db, email, verified_minutes_ago=1):
 
 
 
-def test_complete_signup_requires_verified_otp(client, monkeypatch):
-    fake_db = _FakeDB()
-    monkeypatch.setattr(auth_module, "db", fake_db)
-
+def test_complete_signup_requires_verified_otp(client):
     response = client.post(
         "/api/auth/complete-signup",
         json={
@@ -115,10 +56,8 @@ def test_complete_signup_requires_verified_otp(client, monkeypatch):
 
 
 
-def test_complete_signup_rejects_expired_verified_session(client, monkeypatch):
-    fake_db = _FakeDB()
-    monkeypatch.setattr(auth_module, "db", fake_db)
-    _seed_verified_otp_record(fake_db, "expired@example.com", verified_minutes_ago=11)
+def test_complete_signup_rejects_expired_verified_session(client, mock_db):
+    _seed_verified_otp_record(mock_db, "expired@example.com", verified_minutes_ago=11)
 
     response = client.post(
         "/api/auth/complete-signup",
@@ -134,10 +73,8 @@ def test_complete_signup_rejects_expired_verified_session(client, monkeypatch):
 
 
 
-def test_verify_then_complete_signup_succeeds_within_window(client, monkeypatch):
-    fake_db = _FakeDB()
-    monkeypatch.setattr(auth_module, "db", fake_db)
-    _seed_otp_record(fake_db, "fresh@example.com", otp="654321")
+def test_verify_then_complete_signup_succeeds_within_window(client, mock_db):
+    _seed_otp_record(mock_db, "fresh@example.com", otp="654321")
 
     verify_response = client.post(
         "/api/auth/verify-otp",
@@ -158,14 +95,12 @@ def test_verify_then_complete_signup_succeeds_within_window(client, monkeypatch)
     body = signup_response.get_json()
     assert "access_token" in body
     assert body["role"] == "user"
-    assert fake_db.users.find_one({"email": "fresh@example.com"}) is not None
+    assert mock_db.users.find_one({"email": "fresh@example.com"}) is not None
 
 
 
-def test_set_password_reset_requires_verified_otp(client, monkeypatch):
-    fake_db = _FakeDB()
-    monkeypatch.setattr(auth_module, "db", fake_db)
-    _seed_existing_user(fake_db, "resetuser@example.com", username="reset_user")
+def test_set_password_reset_requires_verified_otp(client, mock_db):
+    _seed_existing_user(mock_db, "resetuser@example.com", username="reset_user")
 
     response = client.post(
         "/api/auth/set-password",
@@ -181,11 +116,9 @@ def test_set_password_reset_requires_verified_otp(client, monkeypatch):
 
 
 
-def test_set_password_reset_rejects_expired_verified_session(client, monkeypatch):
-    fake_db = _FakeDB()
-    monkeypatch.setattr(auth_module, "db", fake_db)
-    _seed_existing_user(fake_db, "resetexpired@example.com", username="reset_expired")
-    _seed_verified_otp_record(fake_db, "resetexpired@example.com", verified_minutes_ago=11)
+def test_set_password_reset_rejects_expired_verified_session(client, mock_db):
+    _seed_existing_user(mock_db, "resetexpired@example.com", username="reset_expired")
+    _seed_verified_otp_record(mock_db, "resetexpired@example.com", verified_minutes_ago=11)
 
     response = client.post(
         "/api/auth/set-password",
@@ -201,11 +134,9 @@ def test_set_password_reset_rejects_expired_verified_session(client, monkeypatch
 
 
 
-def test_verify_then_set_password_reset_succeeds_within_window(client, monkeypatch):
-    fake_db = _FakeDB()
-    monkeypatch.setattr(auth_module, "db", fake_db)
-    _seed_existing_user(fake_db, "resetok@example.com", username="reset_ok")
-    _seed_otp_record(fake_db, "resetok@example.com", otp="111222")
+def test_verify_then_set_password_reset_succeeds_within_window(client, mock_db):
+    _seed_existing_user(mock_db, "resetok@example.com", username="reset_ok")
+    _seed_otp_record(mock_db, "resetok@example.com", otp="111222")
 
     verify_response = client.post(
         "/api/auth/verify-otp",


### PR DESCRIPTION
What:

This pull request refactors the tests/test_auth_otp_security.py  to use the mock_db fixtures.

Why:

Previously, this test  using the [custom fake DB](https://github.com/KathiraveluLab/Beehive/blob/83b13820466e0d3b66f9a764925f1c6ebfa197e0/tests/test_auth_otp_security.py#L6-L58), Since the direct fixture is available now, I have refactored with the mock_db to make it consistent and maintainable.


ref PR: https://github.com/KathiraveluLab/Beehive/pull/641

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
