### PR TITLE
Fix: OTP flow inconsistencies in auth

### DIFF
--- a/frontend/src/pages/auth/ForgotPassword.tsx
+++ b/frontend/src/pages/auth/ForgotPassword.tsx
@@ -1,7 +1,7 @@
 import  { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { apiFetch } from "../../utils/apiFetch";
-import {requestOtpApi } from "./authApi";
+import { requestOtp as requestOtpApi } from "./authApi";
 
 
 const ForgotPasswordPage = () => {

--- a/frontend/src/pages/auth/ForgotPassword.tsx
+++ b/frontend/src/pages/auth/ForgotPassword.tsx
@@ -1,6 +1,7 @@
 import  { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { apiFetch } from "../../utils/apiFetch";
+import {requestOtpApi } from "./authApi";
 
 
 const ForgotPasswordPage = () => {
@@ -40,8 +41,8 @@ const ForgotPasswordPage = () => {
       });
 
       setStep("password");
-    } catch (err: any) {
-      setError(err.message || "Invalid or expired OTP");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Invalid or expired OTP");
     } finally {
       setLoading(false);
     }
@@ -67,8 +68,8 @@ const ForgotPasswordPage = () => {
       });
 
       navigate("/sign-in");
-    } catch (err: any) {
-      setError(err.message || "Failed to reset password");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to reset password");
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { saveToken } from "../../utils/auth";
 import { apiFetch } from "../../utils/apiFetch";
+import {requestOtpApi} from "./authApi";
 
 
 const SignUpPage = () => {

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { saveToken } from "../../utils/auth";
 import { apiFetch } from "../../utils/apiFetch";
-import {requestOtpApi} from "./authApi";
+import { requestOtp as requestOtpApi } from "./authApi";
 
 
 const SignUpPage = () => {

--- a/frontend/src/pages/auth/authApi.ts
+++ b/frontend/src/pages/auth/authApi.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from "../../utils/apiFetch";
 
-export const requestOtpApi = (email: string, purpose: "signup" | "reset") => {
+export const requestOtp = (email: string, purpose: "signup" | "reset") => {
   return apiFetch("/api/auth/request-otp", {
     method: "POST",
     body: JSON.stringify({ email, purpose }),

--- a/frontend/src/pages/auth/authApi.ts
+++ b/frontend/src/pages/auth/authApi.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from "../../utils/apiFetch";
 
-export const requestOtp = (email: string, purpose: "signup" | "reset") => {
+export const requestOtpApi = (email: string, purpose: "signup" | "reset") => {
   return apiFetch("/api/auth/request-otp", {
     method: "POST",
     body: JSON.stringify({ email, purpose }),

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -102,6 +102,7 @@ def request_otp():
         return jsonify({"error": "Invalid purpose"}), 400
 
     otp = create_email_otp(email)
+    print(f"[OTP] {purpose} {email}: {otp}", flush=True)
 
     # send the OTP via email
     try:

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -102,7 +102,8 @@ def request_otp():
         return jsonify({"error": "Invalid purpose"}), 400
 
     otp = create_email_otp(email)
-    current_app.logger.info("[OTP] %s %s: %s", purpose, email, otp)
+    if current_app.debug:
+        current_app.logger.info("[OTP] %s %s: %s", purpose, email, otp)
 
     # send the OTP via email
     try:

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -102,7 +102,7 @@ def request_otp():
         return jsonify({"error": "Invalid purpose"}), 400
 
     otp = create_email_otp(email)
-    print(f"[OTP] {purpose} {email}: {otp}", flush=True)
+    current_app.logger.info("[OTP] %s %s: %s", purpose, email, otp)
 
     # send the OTP via email
     try:


### PR DESCRIPTION
### Summary

- Signup and forgot-password OTP requests were failing because frontend OTP helper usage was inconsistent, causing runtime errors in the OTP request step.

### Changes

- Standardized frontend OTP helper usage around requestOtpApi so both auth pages call the same API helper.
- Kept helper definition centralized at `authApi.ts`.
- Added terminal OTP logger for local visibility .

``` bash
127.0.0.1 - - [13/Apr/2026 22:01:50] "OPTIONS /api/auth/request-otp HTTP/1.1" 200 -
[OTP] signup me@prax.sh: 258056
```

### Impact
- OTP request flow now works consistently for both signup and forgot password .
- No changes to existing email delivery flow.


### Related issue
- Fixes #650 


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
