### PR TITLE
fix: update labeler workflow reference to correct repository

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   call-labeler:
-    uses: shivamyadav-org/.github/.github/workflows/labeler.yml@main
+    uses: KathiraveluLab/.github/.github/workflows/labeler.yml@main
     with:
       issue_title: ${{ github.event.issue.title }}
       issue_body: ${{ github.event.issue.body }}


### PR DESCRIPTION
### Summary

Update checkout repository to use KathiraveluLab/.github instead of shivamyadav-org/.github.


**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
