### PR TITLE
Fix: prevent username collision in set-password signup path

### DIFF
--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -146,9 +146,39 @@ def initialize_text_index():
                         "Cannot create unique username index: duplicate usernames exist. "
                         "Manual deduplication required."
                     )
-            if 'email_1' not in existing_user_indexes:
-                user_collection.create_index([('email', 1)], name='email_1')
-                logger.info("Index created on email in user collection")
+            if 'email_1' in existing_user_indexes:
+                if not existing_user_indexes['email_1'].get('unique'):
+                    try:
+                        user_collection.create_index(
+                            [('email', 1)],
+                            name='email_1_unique_tmp',
+                            unique=True,
+                        )
+                        user_collection.drop_index('email_1')
+                        user_collection.drop_index('email_1_unique_tmp')
+                        user_collection.create_index(
+                            [('email', 1)], name='email_1', unique=True
+                        )
+                        logger.info("Upgraded email_1 index to unique=True")
+                    except MongoDuplicateKeyError:
+                        try:
+                            user_collection.drop_index('email_1_unique_tmp')
+                        except Exception:
+                            pass
+                        logger.error(
+                            "Cannot upgrade email index to unique: duplicate emails "
+                            "exist in the collection. Manual deduplication is required "
+                            "before uniqueness can be enforced."
+                        )
+            else:
+                try:
+                    user_collection.create_index([('email', 1)], name='email_1', unique=True)
+                    logger.info("Unique index created on email in user collection")
+                except MongoDuplicateKeyError:
+                    logger.error(
+                        "Cannot create unique email index: duplicate emails exist. "
+                        "Manual deduplication required."
+                    )
         except Exception as ie:
             logger.error(f"Error creating collection indexes: {ie}")
     except Exception as e:

--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -146,9 +146,42 @@ def initialize_text_index():
                         "Cannot create unique username index: duplicate usernames exist. "
                         "Manual deduplication required."
                     )
-            if 'email_1' not in existing_user_indexes:
-                user_collection.create_index([('email', 1)], name='email_1')
-                logger.info("Index created on email in user collection")
+            if 'email_1' in existing_user_indexes:
+                if not existing_user_indexes['email_1'].get('unique'):
+                    # Safe upgrade: create temp unique index first to catch duplicates
+                    # before touching the existing index.
+                    try:
+                        user_collection.create_index(
+                            [('email', 1)],
+                            name='email_1_unique_tmp',
+                            unique=True,
+                        )
+                        user_collection.drop_index('email_1')
+                        user_collection.drop_index('email_1_unique_tmp')
+                        user_collection.create_index(
+                            [('email', 1)], name='email_1', unique=True
+                        )
+                        logger.info("Upgraded email_1 index to unique=True")
+                    except MongoDuplicateKeyError:
+                        try:
+                            user_collection.drop_index('email_1_unique_tmp')
+                        except Exception:
+                            pass
+                        logger.error(
+                            "Cannot upgrade email index to unique: duplicate emails "
+                            "exist in the collection. Manual deduplication is required "
+                            "before uniqueness can be enforced."
+                        )
+                # else: already unique — nothing to do
+            else:
+                try:
+                    user_collection.create_index([('email', 1)], name='email_1', unique=True)
+                    logger.info("Unique index created on email in user collection")
+                except MongoDuplicateKeyError:
+                    logger.error(
+                        "Cannot create unique email index: duplicate emails exist. "
+                        "Manual deduplication required."
+                    )
         except Exception as ie:
             logger.error(f"Error creating collection indexes: {ie}")
     except Exception as e:

--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -147,7 +147,7 @@ def initialize_text_index():
                         "Manual deduplication required."
                     )
             if 'email_1' not in existing_user_indexes:
-                user_collection.create_index([('email', 1)], name='email_1')
+                user_collection.create_index([('email', 1)], name='email_1', unique=True)
                 logger.info("Index created on email in user collection")
         except Exception as ie:
             logger.error(f"Error creating collection indexes: {ie}")

--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -119,10 +119,10 @@ def initialize_text_index():
                         )
                         # No duplicates confirmed — safe to swap.
                         user_collection.drop_index('username_1')
-                        user_collection.drop_index('username_1_unique_tmp')
                         user_collection.create_index(
                             [('username', 1)], name='username_1', unique=True
                         )
+                        user_collection.drop_index('username_1_unique_tmp')
                         logger.info("Upgraded username_1 index to unique=True")
                     except MongoDuplicateKeyError:
                         # Temp creation failed; old non-unique index is still in place.

--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -157,10 +157,10 @@ def initialize_text_index():
                             unique=True,
                         )
                         user_collection.drop_index('email_1')
-                        user_collection.drop_index('email_1_unique_tmp')
                         user_collection.create_index(
                             [('email', 1)], name='email_1', unique=True
                         )
+                        user_collection.drop_index('email_1_unique_tmp')
                         logger.info("Upgraded email_1 index to unique=True")
                     except MongoDuplicateKeyError:
                         try:

--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -101,9 +101,19 @@ def initialize_text_index():
                 logger.info("Compound index created on user_id and created_at in image collection")
 
             # Add user collection indexes
-            if 'username_1' not in existing_user_indexes:
-                user_collection.create_index([('username', 1)], name='username_1')
-                logger.info("Index created on username in user collection")
+            # The username index MUST be unique to prevent race-condition duplicates.
+            # If an old non-unique index exists, drop it first so we can recreate
+            # it with unique=True.
+            if 'username_1' in existing_user_indexes:
+                if not existing_user_indexes['username_1'].get('unique'):
+                    user_collection.drop_index('username_1')
+                    logger.info("Dropped non-unique username_1 index to replace with unique index")
+                    user_collection.create_index([('username', 1)], name='username_1', unique=True)
+                    logger.info("Unique index created on username in user collection")
+                # else: already unique — nothing to do
+            else:
+                user_collection.create_index([('username', 1)], name='username_1', unique=True)
+                logger.info("Unique index created on username in user collection")
             if 'email_1' not in existing_user_indexes:
                 user_collection.create_index([('email', 1)], name='email_1')
                 logger.info("Index created on email in user collection")

--- a/database/databaseConfig.py
+++ b/database/databaseConfig.py
@@ -1,6 +1,7 @@
 import os
 from dotenv import find_dotenv, load_dotenv
 from pymongo import MongoClient, TEXT
+from pymongo.errors import DuplicateKeyError as MongoDuplicateKeyError
 from utils.logger import Logger
 
 logger = Logger.get_logger("databaseConfig")
@@ -106,14 +107,45 @@ def initialize_text_index():
             # it with unique=True.
             if 'username_1' in existing_user_indexes:
                 if not existing_user_indexes['username_1'].get('unique'):
-                    user_collection.drop_index('username_1')
-                    logger.info("Dropped non-unique username_1 index to replace with unique index")
-                    user_collection.create_index([('username', 1)], name='username_1', unique=True)
-                    logger.info("Unique index created on username in user collection")
+                    # Safe upgrade: create a temporary unique index FIRST to
+                    # detect any duplicate data before we drop anything.
+                    # If duplicates exist, create_index raises DuplicateKeyError
+                    # and the original index is left completely untouched.
+                    try:
+                        user_collection.create_index(
+                            [('username', 1)],
+                            name='username_1_unique_tmp',
+                            unique=True,
+                        )
+                        # No duplicates confirmed — safe to swap.
+                        user_collection.drop_index('username_1')
+                        user_collection.drop_index('username_1_unique_tmp')
+                        user_collection.create_index(
+                            [('username', 1)], name='username_1', unique=True
+                        )
+                        logger.info("Upgraded username_1 index to unique=True")
+                    except MongoDuplicateKeyError:
+                        # Temp creation failed; old non-unique index is still in place.
+                        # Clean up the temp index just in case it was partially recorded.
+                        try:
+                            user_collection.drop_index('username_1_unique_tmp')
+                        except Exception:
+                            pass
+                        logger.error(
+                            "Cannot upgrade username index to unique: duplicate usernames "
+                            "exist in the collection. Manual deduplication is required "
+                            "before uniqueness can be enforced."
+                        )
                 # else: already unique — nothing to do
             else:
-                user_collection.create_index([('username', 1)], name='username_1', unique=True)
-                logger.info("Unique index created on username in user collection")
+                try:
+                    user_collection.create_index([('username', 1)], name='username_1', unique=True)
+                    logger.info("Unique index created on username in user collection")
+                except MongoDuplicateKeyError:
+                    logger.error(
+                        "Cannot create unique username index: duplicate usernames exist. "
+                        "Manual deduplication required."
+                    )
             if 'email_1' not in existing_user_indexes:
                 user_collection.create_index([('email', 1)], name='email_1')
                 logger.info("Index created on email in user collection")

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -54,11 +54,13 @@ def _unique_username(base: str) -> str:
     base = base.replace("@", "").replace("$", "").strip() or "user"
 
     # Fetch every username that matches base or base<digits>.
-    pattern = f"^{re.escape(base)}[0-9]*$"
+    # Define the specific candidates we want to check in-memory.
+    candidates = [base] + [f"{base}{i}" for i in range(1, _MAX_USERNAME_SEQUENTIAL + 1)]
+
     taken = {
         doc["username"]
         for doc in db.users.find(
-            {"username": {"$regex": pattern}},
+            {"username": {"$in": candidates}},
             {"username": 1, "_id": 0},
         )
     }

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -539,7 +539,7 @@ def google_auth():
                     "DuplicateKeyError on Google signup attempt %d/%d for email=%s username=%s",
                     _attempt + 1, _MAX_SIGNUP_RETRIES, email, google_username,
                 )
-                if "email" in str(e):
+                if e.details and e.details.get("keyPattern", {}).get("email"):
                     user = db.users.find_one({"email": email})
                     if user:
                         return jsonify({

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -30,11 +30,11 @@ OTP_VERIFICATION_WINDOW_SECONDS = 600  # 10 minutes
 def _unique_username(base: str) -> str:
     """Return a username derived from *base* that does not already exist.
 
-    Strips any '@' character so the result can never be mistaken for an email
-    address by the login resolver, then appends an incrementing numeric suffix
-    until a free slot is found.
+    Strips any '@' or '$' characters so the result can never be mistaken for
+    an email address or trigger NoSQL injection checks, then appends an
+    incrementing numeric suffix until a free slot is found.
     """
-    base = base.replace("@", "")
+    base = base.replace("@", "").replace("$", "")
     candidate = base
     counter = 1
     while db.users.find_one({"username": candidate}):

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -222,14 +222,21 @@ def complete_signup():
     )
 
     now_utc = datetime.now(timezone.utc)
-    result = db.users.insert_one({
-        "email": email,
-        "username": username,
-        "password": hashed_password,
-        "role": role,
-        "created_at": now_utc,
-        "last_active": now_utc
-    })
+    try:
+        result = db.users.insert_one({
+            "email": email,
+            "username": username,
+            "password": hashed_password,
+            "role": role,
+            "created_at": now_utc,
+            "last_active": now_utc
+        })
+    except pymongo.errors.DuplicateKeyError:
+        current_app.logger.warning(
+            "DuplicateKeyError on complete-signup for email=%s username=%s — race condition",
+            email, username,
+        )
+        return jsonify({"error": "Username already taken. Please choose a different one."}), 409
     db.email_otps.delete_many({"email": email})
 
     token = create_access_token(

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -27,6 +27,22 @@ auth_bp = Blueprint("auth", __name__)
 OTP_VERIFICATION_WINDOW_SECONDS = 600  # 10 minutes
 
 
+def _unique_username(base: str) -> str:
+    """Return a username derived from *base* that does not already exist.
+
+    Strips any '@' character so the result can never be mistaken for an email
+    address by the login resolver, then appends an incrementing numeric suffix
+    until a free slot is found.
+    """
+    base = base.replace("@", "")
+    candidate = base
+    counter = 1
+    while db.users.find_one({"username": candidate}):
+        candidate = f"{base}{counter}"
+        counter += 1
+    return candidate
+
+
 def _validate_otp_verification(email: str):
     """Check that a valid, unexpired OTP verification session exists for email.
 
@@ -331,9 +347,10 @@ def set_password():
         role = "admin" if is_admin_email(email) else "user"
 
         now_utc = datetime.now(timezone.utc)
+        username = _unique_username(email.split("@")[0])
         user_id = db.users.insert_one({
             "email": email,
-            "username": email.split("@")[0],
+            "username": username,
             "password": hashed,
             "role": role,
             "created_at": now_utc,
@@ -415,9 +432,10 @@ def google_auth():
 
         # Create a minimal Google-backed user (no local password)
         now_utc = datetime.now(timezone.utc)
+        google_username = _unique_username(name or email.split("@")[0])
         result = db.users.insert_one({
             "email": email,
-            "username": name or email.split("@")[0],
+            "username": google_username,
             "password": None,
             "role": role,
             "provider": "google",

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -439,9 +439,6 @@ def set_password():
                 if _attempt == _MAX_SIGNUP_RETRIES - 1:
                     return jsonify({"error": "Could not assign a unique username. Please try again."}), 409
 
-        if user_id is None:
-            # All retry attempts exhausted without a successful insert.
-            return jsonify({"error": "Could not assign a unique username. Please try again."}), 409
 
         # Cleanup OTPs
         db.email_otps.delete_many({"email": email})

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, request, jsonify, current_app
 from datetime import datetime, timedelta, timezone
+import re
 import secrets
 import bcrypt
 from google.oauth2 import id_token
@@ -43,24 +44,34 @@ def _unique_username(base: str) -> str:
     an email address or trigger NoSQL injection checks, then appends an
     incrementing numeric suffix until a free slot is found.
 
-    At most _MAX_USERNAME_SEQUENTIAL sequential candidates are checked
-    (bare *base*, then *base1* … *base_MAX*); if all are taken a hex suffix
-    is used to break the collision cluster without spinning indefinitely.
-    The DB unique index is the final backstop against races.
+    A single regex query fetches all taken variants (base, base1 … baseN) so
+    the suffix search is done in-memory without extra round-trips. Falls back
+    to a hex suffix if every sequential slot is occupied. The DB unique index
+    is the final backstop against races.
     """
     # Default to "user" so an all-symbol prefix (e.g. "@") never yields an
     # empty string, which would produce an unusable username.
     base = base.replace("@", "").replace("$", "").strip() or "user"
-    candidate = base
+
+    # Fetch every username that matches base or base<digits>.
+    pattern = f"^{re.escape(base)}[0-9]*$"
+    taken = {
+        doc["username"]
+        for doc in db.users.find(
+            {"username": {"$regex": pattern}},
+            {"username": 1, "_id": 0},
+        )
+    }
+
+    # Try the bare base first, then base1 … base_MAX in-memory.
+    if base not in taken:
+        return base
     for counter in range(1, _MAX_USERNAME_SEQUENTIAL + 1):
-        if not db.users.find_one({"username": candidate}):
-            return candidate
         candidate = f"{base}{counter}"
-    # Check the final sequential candidate (base_MAX) before giving up.
-    if not db.users.find_one({"username": candidate}):
-        return candidate
-    # All sequential slots taken — use a hex suffix to minimise collision risk
-    # (avoids the small-integer overlap that a randbelow(10) fallback would have).
+        if candidate not in taken:
+            return candidate
+
+    # All sequential slots occupied — hex suffix to minimise collision risk.
     return f"{base}{secrets.token_hex(4)}"
 
 

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -44,7 +44,7 @@ def _unique_username(base: str) -> str:
     an email address or trigger NoSQL injection checks, then appends an
     incrementing numeric suffix until a free slot is found.
 
-    A single regex query fetches all taken variants (base, base1 … baseN) so
+    A single query using $in fetches all taken variants (base, base1 … baseN) so
     the suffix search is done in-memory without extra round-trips. Falls back
     to a hex suffix if every sequential slot is occupied. The DB unique index
     is the final backstop against races.

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -434,7 +434,7 @@ def set_password():
                     "DuplicateKeyError on signup attempt %d/%d for email=%s username=%s",
                     _attempt + 1, _MAX_SIGNUP_RETRIES, email, username,
                 )
-                if "email" in str(e):
+                if e.details and e.details.get("keyPattern", {}).get("email"):
                     return jsonify({"error": "Email already registered"}), 409
                 if _attempt == _MAX_SIGNUP_RETRIES - 1:
                     return jsonify({"error": "Could not assign a unique username. Please try again."}), 409

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -432,7 +432,7 @@ def google_auth():
 
         # Create a minimal Google-backed user (no local password)
         now_utc = datetime.now(timezone.utc)
-        google_username = _unique_username(name or email.split("@")[0])
+        google_username = _unique_username((name[:100] if name else None) or email.split("@")[0])
         result = db.users.insert_one({
             "email": email,
             "username": google_username,

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -34,7 +34,7 @@ def _unique_username(base: str) -> str:
     an email address or trigger NoSQL injection checks, then appends an
     incrementing numeric suffix until a free slot is found.
     """
-    base = base.replace("@", "").replace("$", "")
+    base = base.replace("@", "").replace("$", "").strip()
     candidate = base
     counter = 1
     while db.users.find_one({"username": candidate}):

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -4,6 +4,7 @@ import secrets
 import bcrypt
 from google.oauth2 import id_token
 from google.auth.transport import requests as google_requests
+import pymongo.errors
 
 from bson import ObjectId
 from bson.errors import InvalidId
@@ -348,14 +349,21 @@ def set_password():
 
         now_utc = datetime.now(timezone.utc)
         username = _unique_username(email.split("@")[0])
-        user_id = db.users.insert_one({
-            "email": email,
-            "username": username,
-            "password": hashed,
-            "role": role,
-            "created_at": now_utc,
-            "last_active": now_utc
-        }).inserted_id
+        try:
+            user_id = db.users.insert_one({
+                "email": email,
+                "username": username,
+                "password": hashed,
+                "role": role,
+                "created_at": now_utc,
+                "last_active": now_utc
+            }).inserted_id
+        except pymongo.errors.DuplicateKeyError:
+            current_app.logger.warning(
+                "DuplicateKeyError on signup for email=%s username=%s — race condition",
+                email, username,
+            )
+            return jsonify({"error": "Username already taken. Please try again."}), 409
 
         # Cleanup OTPs
         db.email_otps.delete_many({"email": email})
@@ -433,16 +441,23 @@ def google_auth():
         # Create a minimal Google-backed user (no local password)
         now_utc = datetime.now(timezone.utc)
         google_username = _unique_username(name or email.split("@")[0])
-        result = db.users.insert_one({
-            "email": email,
-            "username": google_username,
-            "password": None,
-            "role": role,
-            "provider": "google",
-            "google_id": sub,
-            "created_at": now_utc,
-            "last_active": now_utc
-        })
+        try:
+            result = db.users.insert_one({
+                "email": email,
+                "username": google_username,
+                "password": None,
+                "role": role,
+                "provider": "google",
+                "google_id": sub,
+                "created_at": now_utc,
+                "last_active": now_utc
+            })
+        except pymongo.errors.DuplicateKeyError:
+            current_app.logger.warning(
+                "DuplicateKeyError on Google signup for email=%s username=%s — race condition",
+                email, google_username,
+            )
+            return jsonify({"error": "Username conflict during signup. Please try again."}), 409
         user_id = str(result.inserted_id)
     else:
         user_id = str(user["_id"])

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -396,8 +396,6 @@ def set_password():
         current_app.logger.warning("SET PASSWORD VALIDATION ERROR")
         return jsonify({"error": str(e)}), 400
 
-    if purpose not in ("signup", "reset"):
-        return jsonify({"error": "Invalid purpose. Must be 'signup' or 'reset'."}), 400
 
     if len(password) < 8:
         return jsonify({"error": "Password must be at least 8 characters"}), 400
@@ -440,6 +438,10 @@ def set_password():
                     return jsonify({"error": "Email already registered"}), 409
                 if _attempt == _MAX_SIGNUP_RETRIES - 1:
                     return jsonify({"error": "Could not assign a unique username. Please try again."}), 409
+
+        if user_id is None:
+            # All retry attempts exhausted without a successful insert.
+            return jsonify({"error": "Could not assign a unique username. Please try again."}), 409
 
         # Cleanup OTPs
         db.email_otps.delete_many({"email": email})

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -40,18 +40,25 @@ def _unique_username(base: str) -> str:
     an email address or trigger NoSQL injection checks, then appends an
     incrementing numeric suffix until a free slot is found.
 
-    At most _MAX_USERNAME_SEQUENTIAL sequential candidates are checked; if all
-    are taken a random 7-digit suffix is used to break the collision cluster
-    without spinning indefinitely. The DB unique index is the final backstop.
+    At most _MAX_USERNAME_SEQUENTIAL sequential candidates are checked
+    (bare *base*, then *base1* … *base_MAX*); if all are taken a hex suffix
+    is used to break the collision cluster without spinning indefinitely.
+    The DB unique index is the final backstop against races.
     """
-    base = base.replace("@", "").replace("$", "").strip()
+    # Default to "user" so an all-symbol prefix (e.g. "@") never yields an
+    # empty string, which would produce an unusable username.
+    base = base.replace("@", "").replace("$", "").strip() or "user"
     candidate = base
     for counter in range(1, _MAX_USERNAME_SEQUENTIAL + 1):
         if not db.users.find_one({"username": candidate}):
             return candidate
         candidate = f"{base}{counter}"
-    # Sequential slots all taken — use a random suffix to avoid an unbounded loop.
-    return f"{base}{secrets.randbelow(9_999_999) + 1}"
+    # Check the final sequential candidate (base_MAX) before giving up.
+    if not db.users.find_one({"username": candidate}):
+        return candidate
+    # All sequential slots taken — use a hex suffix to minimise collision risk
+    # (avoids the small-integer overlap that a randbelow(10) fallback would have).
+    return f"{base}{secrets.token_hex(4)}"
 
 
 def _validate_otp_verification(email: str):
@@ -241,13 +248,14 @@ def complete_signup():
             "created_at": now_utc,
             "last_active": now_utc
         })
-    except pymongo.errors.DuplicateKeyError:
+    except pymongo.errors.DuplicateKeyError as e:
         current_app.logger.warning(
             "DuplicateKeyError on complete-signup for email=%s username=%s — race condition",
             email, username,
         )
+        if "email" in str(e):
+            return jsonify({"error": "Email already registered"}), 409
         return jsonify({"error": "Username already taken. Please choose a different one."}), 409
-    db.email_otps.delete_many({"email": email})
 
     token = create_access_token(
         user_id=str(result.inserted_id),
@@ -378,11 +386,13 @@ def set_password():
                     "last_active": now_utc
                 }).inserted_id
                 break  # success
-            except pymongo.errors.DuplicateKeyError:
+            except pymongo.errors.DuplicateKeyError as e:
                 current_app.logger.warning(
                     "DuplicateKeyError on signup attempt %d/%d for email=%s username=%s",
                     _attempt + 1, _MAX_SIGNUP_RETRIES, email, username,
                 )
+                if "email" in str(e):
+                    return jsonify({"error": "Email already registered"}), 409
                 if _attempt == _MAX_SIGNUP_RETRIES - 1:
                     return jsonify({"error": "Could not assign a unique username. Please try again."}), 409
 
@@ -477,11 +487,19 @@ def google_auth():
                     "last_active": now_utc
                 })
                 break  # success
-            except pymongo.errors.DuplicateKeyError:
+            except pymongo.errors.DuplicateKeyError as e:
                 current_app.logger.warning(
                     "DuplicateKeyError on Google signup attempt %d/%d for email=%s username=%s",
                     _attempt + 1, _MAX_SIGNUP_RETRIES, email, google_username,
                 )
+                if "email" in str(e):
+                    user = db.users.find_one({"email": email})
+                    if user:
+                        return jsonify({
+                            "access_token": create_access_token(user_id=str(user["_id"]), role=user.get("role", "user")),
+                            "role": user.get("role", "user")
+                        }), 200
+                    return jsonify({"error": "Failed to authenticate"}), 500
                 if _attempt == _MAX_SIGNUP_RETRIES - 1:
                     return jsonify({"error": "Could not assign a unique username. Please try again."}), 409
         user_id = str(result.inserted_id)

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -298,7 +298,7 @@ def complete_signup():
             "DuplicateKeyError on complete-signup for email=%s username=%s — race condition",
             email, username,
         )
-        if "email" in str(e):
+        if e.details and e.details.get("keyPattern", {}).get("email"):
             return jsonify({"error": "Email already registered"}), 409
         return jsonify({"error": "Username already taken. Please choose a different one."}), 409
 

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -27,6 +27,11 @@ auth_bp = Blueprint("auth", __name__)
 
 OTP_VERIFICATION_WINDOW_SECONDS = 600  # 10 minutes
 
+# Maximum sequential suffix attempts in _unique_username before a random fallback is used.
+_MAX_USERNAME_SEQUENTIAL = 10
+# Maximum full retries (generate + insert) for auto-assigned usernames before giving up.
+_MAX_SIGNUP_RETRIES = 3
+
 
 def _unique_username(base: str) -> str:
     """Return a username derived from *base* that does not already exist.
@@ -34,14 +39,19 @@ def _unique_username(base: str) -> str:
     Strips any '@' or '$' characters so the result can never be mistaken for
     an email address or trigger NoSQL injection checks, then appends an
     incrementing numeric suffix until a free slot is found.
+
+    At most _MAX_USERNAME_SEQUENTIAL sequential candidates are checked; if all
+    are taken a random 7-digit suffix is used to break the collision cluster
+    without spinning indefinitely. The DB unique index is the final backstop.
     """
     base = base.replace("@", "").replace("$", "").strip()
     candidate = base
-    counter = 1
-    while db.users.find_one({"username": candidate}):
+    for counter in range(1, _MAX_USERNAME_SEQUENTIAL + 1):
+        if not db.users.find_one({"username": candidate}):
+            return candidate
         candidate = f"{base}{counter}"
-        counter += 1
-    return candidate
+    # Sequential slots all taken — use a random suffix to avoid an unbounded loop.
+    return f"{base}{secrets.randbelow(9_999_999) + 1}"
 
 
 def _validate_otp_verification(email: str):
@@ -355,22 +365,26 @@ def set_password():
         role = "admin" if is_admin_email(email) else "user"
 
         now_utc = datetime.now(timezone.utc)
-        username = _unique_username(email.split("@")[0])
-        try:
-            user_id = db.users.insert_one({
-                "email": email,
-                "username": username,
-                "password": hashed,
-                "role": role,
-                "created_at": now_utc,
-                "last_active": now_utc
-            }).inserted_id
-        except pymongo.errors.DuplicateKeyError:
-            current_app.logger.warning(
-                "DuplicateKeyError on signup for email=%s username=%s — race condition",
-                email, username,
-            )
-            return jsonify({"error": "Username already taken. Please try again."}), 409
+        user_id = None
+        for _attempt in range(_MAX_SIGNUP_RETRIES):
+            username = _unique_username(email.split("@")[0])
+            try:
+                user_id = db.users.insert_one({
+                    "email": email,
+                    "username": username,
+                    "password": hashed,
+                    "role": role,
+                    "created_at": now_utc,
+                    "last_active": now_utc
+                }).inserted_id
+                break  # success
+            except pymongo.errors.DuplicateKeyError:
+                current_app.logger.warning(
+                    "DuplicateKeyError on signup attempt %d/%d for email=%s username=%s",
+                    _attempt + 1, _MAX_SIGNUP_RETRIES, email, username,
+                )
+                if _attempt == _MAX_SIGNUP_RETRIES - 1:
+                    return jsonify({"error": "Could not assign a unique username. Please try again."}), 409
 
         # Cleanup OTPs
         db.email_otps.delete_many({"email": email})
@@ -447,24 +461,29 @@ def google_auth():
 
         # Create a minimal Google-backed user (no local password)
         now_utc = datetime.now(timezone.utc)
-        google_username = _unique_username(name or email.split("@")[0])
-        try:
-            result = db.users.insert_one({
-                "email": email,
-                "username": google_username,
-                "password": None,
-                "role": role,
-                "provider": "google",
-                "google_id": sub,
-                "created_at": now_utc,
-                "last_active": now_utc
-            })
-        except pymongo.errors.DuplicateKeyError:
-            current_app.logger.warning(
-                "DuplicateKeyError on Google signup for email=%s username=%s — race condition",
-                email, google_username,
-            )
-            return jsonify({"error": "Username conflict during signup. Please try again."}), 409
+        base_name = name or email.split("@")[0]
+        result = None
+        for _attempt in range(_MAX_SIGNUP_RETRIES):
+            google_username = _unique_username(base_name)
+            try:
+                result = db.users.insert_one({
+                    "email": email,
+                    "username": google_username,
+                    "password": None,
+                    "role": role,
+                    "provider": "google",
+                    "google_id": sub,
+                    "created_at": now_utc,
+                    "last_active": now_utc
+                })
+                break  # success
+            except pymongo.errors.DuplicateKeyError:
+                current_app.logger.warning(
+                    "DuplicateKeyError on Google signup attempt %d/%d for email=%s username=%s",
+                    _attempt + 1, _MAX_SIGNUP_RETRIES, email, google_username,
+                )
+                if _attempt == _MAX_SIGNUP_RETRIES - 1:
+                    return jsonify({"error": "Could not assign a unique username. Please try again."}), 409
         user_id = str(result.inserted_id)
     else:
         user_id = str(user["_id"])

--- a/tests/test_set_password.py
+++ b/tests/test_set_password.py
@@ -182,7 +182,7 @@ def test_set_password_signup_username_collision_resolved(mock_token, mock_db, mo
     otp_record = {
         "email": "alice@example.com",
         "verified": True,
-        "verified_at": __import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+        "verified_at": datetime.now(timezone.utc),
     }
 
     inserted_doc = MagicMock(inserted_id="new-id-456")

--- a/tests/test_set_password.py
+++ b/tests/test_set_password.py
@@ -166,3 +166,82 @@ def test_set_password_signup_duplicate_email(mock_db, client):
     assert resp.status_code == 400
     data = resp.get_json()
     assert data["error"] == "User already exists"
+
+
+# ---------------------------------------------------------------------------
+# Tests — username collision handling
+# ---------------------------------------------------------------------------
+
+
+@patch("routes.auth.is_admin_email", return_value=False)
+@patch("routes.auth.db")
+@patch("routes.auth.create_access_token", return_value="mock-jwt-token")
+def test_set_password_signup_username_collision_resolved(mock_token, mock_db, mock_admin, client):
+    """When the email prefix is already taken as a username, _unique_username
+    must generate a suffixed variant instead of silently inserting a duplicate."""
+    otp_record = {
+        "email": "alice@example.com",
+        "verified": True,
+        "verified_at": __import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+    }
+
+    inserted_doc = MagicMock(inserted_id="new-id-456")
+    mock_db.users.insert_one.return_value = inserted_doc
+
+    # Simulate: first find_one (existing-user check) → None,
+    #           second find_one (_unique_username "alice" taken) → existing record,
+    #           third find_one (_unique_username "alice1" free) → None,
+    #           fourth find_one (OTP verification) → otp_record.
+    mock_db.users.find_one.side_effect = [
+        None,          # existing user by email — not found
+        {"_id": "x"}, # "alice" username already taken
+        None,          # "alice1" username is free
+    ]
+    mock_db.email_otps.find_one.return_value = otp_record
+
+    resp = _post_set_password(client, {
+        "email": "alice@example.com",
+        "password": "securepassword123",
+        "purpose": "signup",
+    })
+
+    assert resp.status_code == 200
+
+    # Extract the username that was actually persisted
+    call_args = mock_db.users.insert_one.call_args[0][0]
+    assert call_args["username"] == "alice1", (
+        f"Expected 'alice1' but got '{call_args['username']}'"
+    )
+
+
+@patch("routes.auth.db")
+def test_unique_username_no_collision(mock_db):
+    """_unique_username returns the base name unchanged when it is free."""
+    from routes.auth import _unique_username
+
+    mock_db.users.find_one.return_value = None
+    assert _unique_username("bob") == "bob"
+
+
+@patch("routes.auth.db")
+def test_unique_username_strips_at_sign(mock_db):
+    """_unique_username must strip '@' so the result cannot be parsed as email."""
+    from routes.auth import _unique_username
+
+    mock_db.users.find_one.return_value = None
+    result = _unique_username("user@domain")
+    assert "@" not in result
+
+
+@patch("routes.auth.db")
+def test_unique_username_increments_until_free(mock_db):
+    """_unique_username must keep incrementing the suffix until a slot is free."""
+    from routes.auth import _unique_username
+
+    # "carol" and "carol1" are taken; "carol2" is free
+    mock_db.users.find_one.side_effect = [
+        {"_id": "1"},  # "carol" taken
+        {"_id": "2"},  # "carol1" taken
+        None,          # "carol2" free
+    ]
+    assert _unique_username("carol") == "carol2"

--- a/tests/test_set_password.py
+++ b/tests/test_set_password.py
@@ -239,9 +239,9 @@ def test_unique_username_increments_until_free(mock_db):
     from routes.auth import _unique_username
 
     # "carol" and "carol1" are taken; "carol2" is free
-    mock_db.users.find_one.side_effect = [
-        {"_id": "1"},  # "carol" taken
-        {"_id": "2"},  # "carol1" taken
-        None,          # "carol2" free
+    # "carol" and "carol1" are taken; "carol2" is free
+    mock_db.users.find.return_value = [
+        {"username": "carol"},
+        {"username": "carol1"},
     ]
     assert _unique_username("carol") == "carol2"


### PR DESCRIPTION
### Summary

Signing up via the `/api/auth/set-password` endpoint could silently create duplicate usernames, causing login to resolve to the wrong account.

### Root cause
- `set_password()` auto-assigned a username from the email prefix with no uniqueness check:
- If two users registered with `alice@gmail.com` and `alice@outlook.com`, both received the username alice. The login resolver at line 244 uses a MongoDB $or query on {username, email} — find_one returns whichever document the DB engine happens to return first, silently authenticating the wrong user.

### Changes
- Added new helper function ( _unique_username()) 
    - @ stripping — ensures the auto-generated username can never be misidentified as an email by the $or login resolver (which branches on "@" in identifier).
- Added 4 new tests in test_set_password.py

### Testing
- Run the set-password test suite:
``` bash
pytest tests/test_set_password.py -v
```

**Checklist:**
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/KathiraveluLab/Beehive/blob/main/docs/contributing.md#3-create-meaningful-pull-request-titles-and-descriptions)
